### PR TITLE
[#19] feat: 로그인 과정에서 이메일 or 비밀번호 중에 하나라도 빈 칸일 경우의 예외처리

### DIFF
--- a/taxi-carpool/.gitignore
+++ b/taxi-carpool/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment file ###
+.env

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -18,7 +18,12 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyFullExceptio
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -37,6 +42,15 @@ public class GlobalExceptionHandler {
         HttpServletRequest request) {
         return new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(),
             request.getRequestURI());
+    }
+
+    // 빈 JSON이나 잘못된 형식으로 인한 예외 처리
+    @ExceptionHandler({MethodArgumentNotValidException.class,
+        HttpMessageNotReadableException.class})
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(Exception ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("message", "이메일과 패스워드 모두 입력해주세요");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(TokenInvalidException.class)


### PR DESCRIPTION
- 400에러가 나오도록 새로운 예외처리 만들었는데, 예외처리가 정상적으로 동작하지 않음.
- 요청 본문이 빈 JSON일 경우, 스프링이 로그인 메서드로 진입하기 전에 검증 예외(예: MethodArgumentNotValidException 또는 HttpMessageNotReadableException)를 던지기 때문에 발생한다고 함. 
- 고로 MethodArgumentNotValidException와 HttpMessageNotReadableException에 대해서 전역 예외 처리기에 정의해두었음.