### PR TITLE
[#22] feat: party에 위도/경도를 표현하는 필드 및 관련 로직

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDelet
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyFullException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
+import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
@@ -33,15 +34,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PartyNotFoundException.class)
     public ResponseEntity<ErrorResponseDTO> handlePartyNotFoundException(PartyNotFoundException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.NOT_FOUND.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.NOT_FOUND.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
     @ExceptionHandler(AuthenticationFailedException.class)
-    public ResponseEntity<ErrorResponseDTO> handleAuthenticationFailedException(AuthenticationFailedException ex,
+    public ResponseEntity<ErrorResponseDTO> handleAuthenticationFailedException(
+        AuthenticationFailedException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
@@ -58,39 +62,48 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TokenInvalidException.class)
     public ResponseEntity<ErrorResponseDTO> handleTokenInvalidException(TokenInvalidException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex,
+    public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(
+        IllegalArgumentException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.BAD_REQUEST.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.BAD_REQUEST.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(MemberNotFoundException.class)
-    public ResponseEntity<ErrorResponseDTO> handleMemberNotFoundException(MemberNotFoundException ex,
+    public ResponseEntity<ErrorResponseDTO> handleMemberNotFoundException(
+        MemberNotFoundException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.NOT_FOUND.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.NOT_FOUND.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
     @ExceptionHandler(MemberNotInPartyException.class)
-    public ResponseEntity<ErrorResponseDTO> handleMemberNotInPartyException(MemberNotInPartyException ex,
+    public ResponseEntity<ErrorResponseDTO> handleMemberNotInPartyException(
+        MemberNotInPartyException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.BAD_REQUEST.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.BAD_REQUEST.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(PartyAlreadyDeletedException.class)
-    public ResponseEntity<ErrorResponseDTO> handlePartyAlreadyDeletedException(PartyAlreadyDeletedException ex,
+    public ResponseEntity<ErrorResponseDTO> handlePartyAlreadyDeletedException(
+        PartyAlreadyDeletedException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.GONE.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.GONE.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.GONE).body(errorResponse);
     }
@@ -98,7 +111,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PartyEmptyException.class)
     public ResponseEntity<ErrorResponseDTO> handlePartyEmptyException(PartyEmptyException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.GONE.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.GONE.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.GONE).body(errorResponse);
     }
@@ -106,7 +120,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UnauthorizedHostAccessException.class)
     public ResponseEntity<ErrorResponseDTO> handleUnauthorizedHostAccessException(
         UnauthorizedHostAccessException ex, HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.FORBIDDEN.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.FORBIDDEN.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
@@ -114,7 +129,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TokenExpiredException.class)
     public ResponseEntity<ErrorResponseDTO> handleTokenExpiredException(TokenExpiredException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
@@ -122,23 +138,28 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PartyFullException.class)
     public ResponseEntity<ErrorResponseDTO> handlePartyFullException(PartyFullException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
     @ExceptionHandler(DuplicatedNicknameException.class)
-    public ResponseEntity<ErrorResponseDTO> handleDuplicatedNicknameException(DuplicatedNicknameException ex,
+    public ResponseEntity<ErrorResponseDTO> handleDuplicatedNicknameException(
+        DuplicatedNicknameException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
     @ExceptionHandler(DuplicatedEmailException.class)
-    public ResponseEntity<ErrorResponseDTO> handleDuplicatedEmailException(DuplicatedEmailException ex,
+    public ResponseEntity<ErrorResponseDTO> handleDuplicatedEmailException(
+        DuplicatedEmailException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
@@ -147,15 +168,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleEmailVerificationNotFoundException(
         EmailVerificationNotFoundException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.NOT_FOUND.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.NOT_FOUND.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
     @ExceptionHandler(EmailSendFailedException.class)
-    public ResponseEntity<ErrorResponseDTO> handleEmailSendFailedException(EmailSendFailedException ex,
+    public ResponseEntity<ErrorResponseDTO> handleEmailSendFailedException(
+        EmailSendFailedException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
@@ -164,7 +188,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleInvalidVerificationCodeException(
         InvalidVerificationCodeException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
@@ -173,7 +198,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleExpiredVerificationCodeException(
         ExpiredVerificationCodeException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
@@ -182,15 +208,29 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleKakaoApiParseException(
         KakaoApiParseException ex,
         HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(),
             request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    @ExceptionHandler(PartyGetCustomException.class)
+    public ResponseEntity<ErrorResponseDTO> handlePartyServiceException(PartyGetCustomException ex,
+        HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            ex.getMessage(),
+            request.getRequestURI()
+        );
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
 
     // 그 외 잡히지 않은 모든 예외에 대한 전역 핸들러
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponseDTO> handleException(Exception ex, HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다.",
+    public ResponseEntity<ErrorResponseDTO> handleException(Exception ex,
+        HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다.",
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -218,11 +218,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handlePartyServiceException(PartyGetCustomException ex,
         HttpServletRequest request) {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
-            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            HttpStatus.BAD_REQUEST.value(),
             ex.getMessage(),
             request.getRequestURI()
         );
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     // 그 외 잡히지 않은 모든 예외에 대한 전역 핸들러

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
@@ -4,6 +4,7 @@ import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyCreateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyResponseDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyUpdateRequestDTO;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import java.time.LocalDateTime;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,22 +43,22 @@ public class PartyController {
 
     @GetMapping
     public ResponseEntity<Page<PartyResponseDTO>> getPartyList(
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size
+        @RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") Integer page,
+        @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") Integer size
     ) {
         Page<PartyResponseDTO> partyList = partyService.getPartyList(page, size);
         return ResponseEntity.ok(partyList);
     }
 
-    @GetMapping("/custom/native")
+    @GetMapping("/custom")
     public ResponseEntity<Page<PartyResponseDTO>> getCustomPartyList(
-        @RequestParam double userDepartureLng,
-        @RequestParam double userDepartureLat,
-        @RequestParam double userDestinationLng,
-        @RequestParam double userDestinationLat,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime userDepartureTime,
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size
+        @RequestParam(required = false) Double userDepartureLng,
+        @RequestParam(required = false) Double userDepartureLat,
+        @RequestParam(required = false) Double userDestinationLng,
+        @RequestParam(required = false) Double userDestinationLat,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime userDepartureTime,
+        @RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") Integer page,
+        @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") Integer size
     ) {
         Page<PartyResponseDTO> partyList = partyService.getCustomPartyList(userDepartureLng,
             userDepartureLat,

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
@@ -4,9 +4,11 @@ import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyCreateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyResponseDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyUpdateRequestDTO;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,6 +46,23 @@ public class PartyController {
         @RequestParam(defaultValue = "10") int size
     ) {
         Page<PartyResponseDTO> partyList = partyService.getPartyList(page, size);
+        return ResponseEntity.ok(partyList);
+    }
+
+    @GetMapping("/custom/native")
+    public ResponseEntity<Page<PartyResponseDTO>> getCustomPartyList(
+        @RequestParam double userDepartureLng,
+        @RequestParam double userDepartureLat,
+        @RequestParam double userDestinationLng,
+        @RequestParam double userDestinationLat,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime userDepartureTime,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<PartyResponseDTO> partyList = partyService.getCustomPartyList(userDepartureLng,
+            userDepartureLat,
+            userDestinationLng, userDestinationLat,
+            userDepartureTime, page, size);
         return ResponseEntity.ok(partyList);
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
@@ -1,6 +1,7 @@
 package edu.kangwon.university.taxicarpool.party;
 
 import edu.kangwon.university.taxicarpool.member.MemberEntity;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -282,6 +283,7 @@ public class PartyDTO {
         private boolean destinationChangeIn5Minutes;
 
         @NotNull
+        @Future(message = "출발 시간은 현재 시간보다 이후여야 합니다.")
         @NotBlank(message = "출발 시간 입력은 필수입니다.")
         private LocalDateTime startDateTime;
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
@@ -45,9 +45,13 @@ public class PartyDTO {
 
         private int maxParticipantCount;
 
-        private double x;
+        private double start_x;
 
-        private double y;
+        private double start_y;
+
+        private double end_x;
+
+        private double end_y;
 
         public PartyResponseDTO(Long id,
             String name,
@@ -65,8 +69,10 @@ public class PartyDTO {
             String comment,
             int currentParticipantCount,
             int maxParticipantCount,
-            double x,
-            double y) {
+            double start_x,
+            double start_y,
+            double end_x,
+            double end_y) {
             this.id = id;
             this.name = name;
             this.isDeleted = isDeleted;
@@ -83,8 +89,10 @@ public class PartyDTO {
             this.comment = comment;
             this.currentParticipantCount = currentParticipantCount;
             this.maxParticipantCount = maxParticipantCount;
-            this.x = x;
-            this.y = y;
+            this.start_x = start_x;
+            this.start_y = start_y;
+            this.end_x = end_x;
+            this.end_y = end_y;
         }
 
         public Long getId() {
@@ -215,20 +223,36 @@ public class PartyDTO {
             this.maxParticipantCount = maxParticipantCount;
         }
 
-        public double getX() {
-            return x;
+        public double getStart_x() {
+            return start_x;
         }
 
-        public void setX(double x) {
-            this.x = x;
+        public void setStart_x(double start_x) {
+            this.start_x = start_x;
         }
 
-        public double getY() {
-            return y;
+        public double getStart_y() {
+            return start_y;
         }
 
-        public void setY(double y) {
-            this.y = y;
+        public void setStart_y(double start_y) {
+            this.start_y = start_y;
+        }
+
+        public double getEnd_x() {
+            return end_x;
+        }
+
+        public void setEnd_x(double end_x) {
+            this.end_x = end_x;
+        }
+
+        public double getEnd_y() {
+            return end_y;
+        }
+
+        public void setEnd_y(double end_y) {
+            this.end_y = end_y;
         }
     }
 
@@ -277,9 +301,13 @@ public class PartyDTO {
         @Max(value = 4, message = "택시의 최대 탑승 인원 수는 4명입니다.")
         private int maxParticipantCount;
 
-        private double x;
+        private double start_x;
 
-        private double y;
+        private double start_y;
+
+        private double end_x;
+
+        private double end_y;
 
         public PartyCreateRequestDTO(String name,
             boolean isDeleted,
@@ -296,8 +324,10 @@ public class PartyDTO {
             String comment,
             int currentParticipantCount,
             int maxParticipantCount,
-            double x,
-            double y) {
+            double start_x,
+            double start_y,
+            double end_x,
+            double end_y) {
             this.name = name;
             this.isDeleted = isDeleted;
             this.memberEntities = memberEntities;
@@ -313,8 +343,10 @@ public class PartyDTO {
             this.comment = comment;
             this.currentParticipantCount = currentParticipantCount;
             this.maxParticipantCount = maxParticipantCount;
-            this.x = x;
-            this.y = y;
+            this.start_x = start_x;
+            this.start_y = start_y;
+            this.end_x = end_x;
+            this.end_y = end_y;
         }
 
         public String getName() {
@@ -437,20 +469,36 @@ public class PartyDTO {
             this.maxParticipantCount = maxParticipantCount;
         }
 
-        public double getX() {
-            return x;
+        public double getStart_x() {
+            return start_x;
         }
 
-        public void setX(double x) {
-            this.x = x;
+        public void setStart_x(double start_x) {
+            this.start_x = start_x;
         }
 
-        public double getY() {
-            return y;
+        public double getStart_y() {
+            return start_y;
         }
 
-        public void setY(double y) {
-            this.y = y;
+        public void setStart_y(double start_y) {
+            this.start_y = start_y;
+        }
+
+        public double getEnd_x() {
+            return end_x;
+        }
+
+        public void setEnd_x(double end_x) {
+            this.end_x = end_x;
+        }
+
+        public double getEnd_y() {
+            return end_y;
+        }
+
+        public void setEnd_y(double end_y) {
+            this.end_y = end_y;
         }
     }
 
@@ -495,9 +543,13 @@ public class PartyDTO {
         @Max(value = 4, message = "택시의 최대 탑승 인원 수는 4명입니다.")
         private int maxParticipantCount;
 
-        private double x;
+        private double start_x;
 
-        private double y;
+        private double start_y;
+
+        private double end_x;
+
+        private double end_y;
 
         public PartyUpdateRequestDTO(
             String name,
@@ -514,8 +566,10 @@ public class PartyDTO {
             String endLocation,
             String comment,
             int maxParticipantCount,
-            double x,
-            double y
+            double start_x,
+            double start_y,
+            double end_x,
+            double end_y
         ) {
             this.name = name;
             this.isDeleted = isDeleted;
@@ -531,8 +585,10 @@ public class PartyDTO {
             this.endLocation = endLocation;
             this.comment = comment;
             this.maxParticipantCount = maxParticipantCount;
-            this.x = x;
-            this.y = y;
+            this.start_x = start_x;
+            this.start_y = start_y;
+            this.end_x = end_x;
+            this.end_y = end_y;
         }
 
         public String getName() {
@@ -647,20 +703,36 @@ public class PartyDTO {
             this.maxParticipantCount = maxParticipantCount;
         }
 
-        public double getX() {
-            return x;
+        public double getStart_x() {
+            return start_x;
         }
 
-        public void setX(double x) {
-            this.x = x;
+        public void setStart_x(double start_x) {
+            this.start_x = start_x;
         }
 
-        public double getY() {
-            return y;
+        public double getStart_y() {
+            return start_y;
         }
 
-        public void setY(double y) {
-            this.y = y;
+        public void setStart_y(double start_y) {
+            this.start_y = start_y;
+        }
+
+        public double getEnd_x() {
+            return end_x;
+        }
+
+        public void setEnd_x(double end_x) {
+            this.end_x = end_x;
+        }
+
+        public double getEnd_y() {
+            return end_y;
+        }
+
+        public void setEnd_y(double end_y) {
+            this.end_y = end_y;
         }
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
@@ -45,6 +45,10 @@ public class PartyDTO {
 
         private int maxParticipantCount;
 
+        private double x;
+
+        private double y;
+
         public PartyResponseDTO(Long id,
             String name,
             boolean isDeleted,
@@ -60,7 +64,9 @@ public class PartyDTO {
             String endLocation,
             String comment,
             int currentParticipantCount,
-            int maxParticipantCount) {
+            int maxParticipantCount,
+            double x,
+            double y) {
             this.id = id;
             this.name = name;
             this.isDeleted = isDeleted;
@@ -77,6 +83,8 @@ public class PartyDTO {
             this.comment = comment;
             this.currentParticipantCount = currentParticipantCount;
             this.maxParticipantCount = maxParticipantCount;
+            this.x = x;
+            this.y = y;
         }
 
         public Long getId() {
@@ -206,9 +214,25 @@ public class PartyDTO {
         public void setMaxParticipantCount(int maxParticipantCount) {
             this.maxParticipantCount = maxParticipantCount;
         }
+
+        public double getX() {
+            return x;
+        }
+
+        public void setX(double x) {
+            this.x = x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public void setY(double y) {
+            this.y = y;
+        }
     }
 
-    // creatorMemberId 필드 존재
+    // creatorMemberId 필드 존재, hostMemberId필드 삭제 -> creatorMemberId사용의 강제를 위해.
     public static class PartyCreateRequestDTO {
 
         @NotNull
@@ -219,8 +243,6 @@ public class PartyDTO {
         private boolean isDeleted;
 
         private List<MemberEntity> memberEntities = new ArrayList<>();
-
-        private Long hostMemberId;
 
         private LocalDateTime endDate;
 
@@ -255,10 +277,13 @@ public class PartyDTO {
         @Max(value = 4, message = "택시의 최대 탑승 인원 수는 4명입니다.")
         private int maxParticipantCount;
 
+        private double x;
+
+        private double y;
+
         public PartyCreateRequestDTO(String name,
             boolean isDeleted,
             List<MemberEntity> memberEntities,
-            Long hostMemberId,
             LocalDateTime endDate,
             Long creatorMemberId,
             boolean sameGenderOnly,
@@ -270,11 +295,12 @@ public class PartyDTO {
             String endLocation,
             String comment,
             int currentParticipantCount,
-            int maxParticipantCount) {
+            int maxParticipantCount,
+            double x,
+            double y) {
             this.name = name;
             this.isDeleted = isDeleted;
             this.memberEntities = memberEntities;
-            this.hostMemberId = hostMemberId;
             this.endDate = endDate;
             this.creatorMemberId = creatorMemberId;
             this.sameGenderOnly = sameGenderOnly;
@@ -287,6 +313,8 @@ public class PartyDTO {
             this.comment = comment;
             this.currentParticipantCount = currentParticipantCount;
             this.maxParticipantCount = maxParticipantCount;
+            this.x = x;
+            this.y = y;
         }
 
         public String getName() {
@@ -311,14 +339,6 @@ public class PartyDTO {
 
         public void setMemberEntities(List<MemberEntity> memberEntities) {
             this.memberEntities = memberEntities;
-        }
-
-        public Long getHostMemberId() {
-            return hostMemberId;
-        }
-
-        public void setHostMemberId(Long hostMemberId) {
-            this.hostMemberId = hostMemberId;
         }
 
         public LocalDateTime getEndDate() {
@@ -416,6 +436,22 @@ public class PartyDTO {
         public void setMaxParticipantCount(int maxParticipantCount) {
             this.maxParticipantCount = maxParticipantCount;
         }
+
+        public double getX() {
+            return x;
+        }
+
+        public void setX(double x) {
+            this.x = x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public void setY(double y) {
+            this.y = y;
+        }
     }
 
     // UpdateRequestDTO에는 현재 인원수에 대한 필드가 없음 -> 파티의 인원수에 관한 로직은 무조건 join/leave 엔트포인트 사용을 강제를 위해
@@ -459,6 +495,10 @@ public class PartyDTO {
         @Max(value = 4, message = "택시의 최대 탑승 인원 수는 4명입니다.")
         private int maxParticipantCount;
 
+        private double x;
+
+        private double y;
+
         public PartyUpdateRequestDTO(
             String name,
             boolean isDeleted,
@@ -473,7 +513,10 @@ public class PartyDTO {
             String startLocation,
             String endLocation,
             String comment,
-            int maxParticipantCount) {
+            int maxParticipantCount,
+            double x,
+            double y
+        ) {
             this.name = name;
             this.isDeleted = isDeleted;
             this.memberEntities = memberEntities;
@@ -488,6 +531,8 @@ public class PartyDTO {
             this.endLocation = endLocation;
             this.comment = comment;
             this.maxParticipantCount = maxParticipantCount;
+            this.x = x;
+            this.y = y;
         }
 
         public String getName() {
@@ -600,6 +645,22 @@ public class PartyDTO {
 
         public void setMaxParticipantCount(int maxParticipantCount) {
             this.maxParticipantCount = maxParticipantCount;
+        }
+
+        public double getX() {
+            return x;
+        }
+
+        public void setX(double x) {
+            this.x = x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public void setY(double y) {
+            this.y = y;
         }
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
@@ -39,7 +39,9 @@ public class PartyEntity {
         String endLocation,
         String comment,
         int currentParticipantCount,
-        int maxParticipantCount
+        int maxParticipantCount,
+        double x,
+        double y
     ) {
         this.name = name;
         this.isDeleted = false;
@@ -56,6 +58,8 @@ public class PartyEntity {
         this.comment = comment;
         this.currentParticipantCount = currentParticipantCount;
         this.maxParticipantCount = maxParticipantCount;
+        this.x = x;
+        this.y = y;
     }
 
     @Id
@@ -113,6 +117,12 @@ public class PartyEntity {
 
     @Column(name = "max_participant_count")
     private int maxParticipantCount;
+
+    @Column(name = "longitude")
+    private double x;
+
+    @Column(name = "latitude")
+    private double y;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -250,6 +260,22 @@ public class PartyEntity {
         this.maxParticipantCount = maxParticipantCount;
     }
 
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
     public PartyEntity updateParty(
         String name,
         boolean isDeleted,
@@ -264,7 +290,9 @@ public class PartyEntity {
         String startLocation,
         String endLocation,
         String comment,
-        int maxParticipantCount
+        int maxParticipantCount,
+        double x,
+        double y
     ) {
         this.name = name;
         this.isDeleted = isDeleted;
@@ -280,6 +308,8 @@ public class PartyEntity {
         this.endLocation = endLocation;
         this.comment = comment;
         this.maxParticipantCount = maxParticipantCount;
+        this.x = x;
+        this.y = y;
         return this;
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
@@ -40,8 +40,10 @@ public class PartyEntity {
         String comment,
         int currentParticipantCount,
         int maxParticipantCount,
-        double x,
-        double y
+        double start_x,
+        double start_y,
+        double end_x,
+        double end_y
     ) {
         this.name = name;
         this.isDeleted = false;
@@ -58,8 +60,10 @@ public class PartyEntity {
         this.comment = comment;
         this.currentParticipantCount = currentParticipantCount;
         this.maxParticipantCount = maxParticipantCount;
-        this.x = x;
-        this.y = y;
+        this.start_x = start_x;
+        this.start_y = start_y;
+        this.end_x = end_x;
+        this.end_y = end_y;
     }
 
     @Id
@@ -118,11 +122,17 @@ public class PartyEntity {
     @Column(name = "max_participant_count")
     private int maxParticipantCount;
 
-    @Column(name = "longitude")
-    private double x;
+    @Column(name = "start_longitude")
+    private double start_x;
 
-    @Column(name = "latitude")
-    private double y;
+    @Column(name = "start_latitude")
+    private double start_y;
+
+    @Column(name = "end_longitude")
+    private double end_x;
+
+    @Column(name = "end_latitude")
+    private double end_y;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -260,20 +270,36 @@ public class PartyEntity {
         this.maxParticipantCount = maxParticipantCount;
     }
 
-    public double getX() {
-        return x;
+    public double getStart_x() {
+        return start_x;
     }
 
-    public void setX(double x) {
-        this.x = x;
+    public void setStart_x(double start_x) {
+        this.start_x = start_x;
     }
 
-    public double getY() {
-        return y;
+    public double getStart_y() {
+        return start_y;
     }
 
-    public void setY(double y) {
-        this.y = y;
+    public void setStart_y(double start_y) {
+        this.start_y = start_y;
+    }
+
+    public double getEnd_x() {
+        return end_x;
+    }
+
+    public void setEnd_x(double end_x) {
+        this.end_x = end_x;
+    }
+
+    public double getEnd_y() {
+        return end_y;
+    }
+
+    public void setEnd_y(double end_y) {
+        this.end_y = end_y;
     }
 
     public PartyEntity updateParty(
@@ -291,8 +317,10 @@ public class PartyEntity {
         String endLocation,
         String comment,
         int maxParticipantCount,
-        double x,
-        double y
+        double start_x,
+        double start_y,
+        double end_x,
+        double end_y
     ) {
         this.name = name;
         this.isDeleted = isDeleted;
@@ -308,8 +336,10 @@ public class PartyEntity {
         this.endLocation = endLocation;
         this.comment = comment;
         this.maxParticipantCount = maxParticipantCount;
-        this.x = x;
-        this.y = y;
+        this.start_x = start_x;
+        this.start_y = start_y;
+        this.end_x = end_x;
+        this.end_y = end_y;
         return this;
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyMapper.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyMapper.java
@@ -27,8 +27,10 @@ public class PartyMapper {
             partyEntity.getComment(),
             partyEntity.getCurrentParticipantCount(),
             partyEntity.getMaxParticipantCount(),
-            partyEntity.getX(),
-            partyEntity.getY()
+            partyEntity.getStart_x(),
+            partyEntity.getStart_y(),
+            partyEntity.getEnd_x(),
+            partyEntity.getEnd_y()
         );
     }
 
@@ -48,8 +50,10 @@ public class PartyMapper {
             createRequestDTO.getComment(),
             createRequestDTO.getCurrentParticipantCount(),
             createRequestDTO.getMaxParticipantCount(),
-            createRequestDTO.getX(),
-            createRequestDTO.getY()
+            createRequestDTO.getStart_x(),
+            createRequestDTO.getStart_y(),
+            createRequestDTO.getEnd_x(),
+            createRequestDTO.getEnd_y()
         );
     }
 
@@ -71,8 +75,10 @@ public class PartyMapper {
             partyUpdateRequestDTO.getEndLocation(),
             partyUpdateRequestDTO.getComment(),
             partyUpdateRequestDTO.getMaxParticipantCount(),
-            partyUpdateRequestDTO.getX(),
-            partyUpdateRequestDTO.getY()
+            partyUpdateRequestDTO.getStart_x(),
+            partyUpdateRequestDTO.getStart_y(),
+            partyUpdateRequestDTO.getEnd_x(),
+            partyUpdateRequestDTO.getEnd_y()
         );
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyMapper.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyMapper.java
@@ -26,7 +26,9 @@ public class PartyMapper {
             partyEntity.getEndLocation(),
             partyEntity.getComment(),
             partyEntity.getCurrentParticipantCount(),
-            partyEntity.getMaxParticipantCount()
+            partyEntity.getMaxParticipantCount(),
+            partyEntity.getX(),
+            partyEntity.getY()
         );
     }
 
@@ -34,7 +36,7 @@ public class PartyMapper {
         return new PartyEntity(
             createRequestDTO.getName(),
             createRequestDTO.getMemberEntities(),
-            createRequestDTO.getHostMemberId(),
+            null,
             createRequestDTO.getEndDate(),
             createRequestDTO.isSameGenderOnly(),
             createRequestDTO.isCostShareBeforeDropOff(),
@@ -45,7 +47,9 @@ public class PartyMapper {
             createRequestDTO.getEndLocation(),
             createRequestDTO.getComment(),
             createRequestDTO.getCurrentParticipantCount(),
-            createRequestDTO.getMaxParticipantCount()
+            createRequestDTO.getMaxParticipantCount(),
+            createRequestDTO.getX(),
+            createRequestDTO.getY()
         );
     }
 
@@ -66,7 +70,9 @@ public class PartyMapper {
             partyUpdateRequestDTO.getStartLocation(),
             partyUpdateRequestDTO.getEndLocation(),
             partyUpdateRequestDTO.getComment(),
-            partyUpdateRequestDTO.getMaxParticipantCount()
+            partyUpdateRequestDTO.getMaxParticipantCount(),
+            partyUpdateRequestDTO.getX(),
+            partyUpdateRequestDTO.getY()
         );
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
@@ -1,11 +1,42 @@
 package edu.kangwon.university.taxicarpool.party;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
 
 @Repository
 public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
 
     Optional<PartyEntity> findById(Long partyId);
+
+    @Query(value = "SELECT p.*, " +
+        " (ST_Distance_Sphere(" +
+        "    ST_GeomFromText(CONCAT('POINT(', p.start_longitude, ' ', p.start_latitude, ')')), " +
+        "    ST_GeomFromText(CONCAT('POINT(', :userDepartureLng, ' ', :userDepartureLat, ')'))" +
+        " ) + " +
+        " ST_Distance_Sphere(" +
+        "    ST_GeomFromText(CONCAT('POINT(', p.end_longitude, ' ', p.end_latitude, ')')), " +
+        "    ST_GeomFromText(CONCAT('POINT(', :userDestinationLng, ' ', :userDestinationLat, ')'))"
+        +
+        " )" +
+        " ) AS total_distance " +
+        "FROM party p " +
+        "ORDER BY total_distance ASC, ABS(TIMESTAMPDIFF(MINUTE, p.start_date_time, :userDepartureTime)) ASC",
+        countQuery = "SELECT COUNT(*) FROM party p",
+        nativeQuery = true)
+    Page<PartyEntity> findCustomPartyList(
+        @Param("userDepartureLng") double userDepartureLng,
+        @Param("userDepartureLat") double userDepartureLat,
+        @Param("userDestinationLng") double userDestinationLng,
+        @Param("userDestinationLat") double userDestinationLat,
+        @Param("userDepartureTime") LocalDateTime userDepartureTime,
+        Pageable pageable
+    );
+
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -10,9 +10,11 @@ import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyE
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyFullException;
+import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,10 +51,27 @@ public class PartyService {
 
     public Page<PartyResponseDTO> getPartyList(int page, int size) {
         if (page < 0 || size <= 0) {
-            throw new IllegalArgumentException("페이지 번호 또는 페이지 크기가 올바르지 않습니다.");
+            throw new PartyGetCustomException("페이지 번호 또는 페이지 크기가 올바르지 않습니다.");
         }
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<PartyEntity> partyEntities = partyRepository.findAll(pageable);
+        return partyEntities.map(partyMapper::convertToResponseDTO);
+    }
+
+    @Transactional
+    public Page<PartyResponseDTO> getCustomPartyList(double userDepartureLng,
+        double userDepartureLat,
+        double userDestinationLng, double userDestinationLat,
+        LocalDateTime userDepartureTime,
+        int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        if (page < 0 || size <= 0) {
+            throw new PartyGetCustomException("페이지 번호 또는 페이지 크기가 올바르지 않습니다.");
+        }
+        Page<PartyEntity> partyEntities = partyRepository.findCustomPartyList(userDepartureLng,
+            userDepartureLat,
+            userDestinationLng, userDestinationLat,
+            userDepartureTime, pageable);
         return partyEntities.map(partyMapper::convertToResponseDTO);
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/PartyGetCustomException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/PartyGetCustomException.java
@@ -1,0 +1,10 @@
+package edu.kangwon.university.taxicarpool.party.partyException;
+
+public class PartyGetCustomException extends RuntimeException {
+
+    public PartyGetCustomException(String message) {
+        super(message);
+    }
+
+}
+


### PR DESCRIPTION
### 파티방 GET요청에 대한 사용자 맞춤형 getCustomPartyList 구현

- 파라미터에 따른 모든 경우의 수를 구현하였고 상세 내용은 다음과 같습니다.

- - 사용자 출발지의 경도/위도, 도착지의 경도/위도, 사용자의 출발시간. 이렇게 5개의 ReuqestParam이 온다. 
1. 출발지의 파라미터가 오면 경도/위도가 다 와야한다. 예를들어 출발지의 경도만 오고 위도만 오는 상황은 출발지의 경도, 위도 모두 null이 온 것이라고 간주함. 
2. 모든 파리미터가 오는 상황 -> 출발지, 도착지, 출발 시간으로 쿼리 작성
3. 사용자의 출발지의 경도, 위도가 오지 않는 상황. -> 도착지, 출발시간에 대한 기준으로만 쿼리 작성.
4. 사용자의 도착지의 경도, 위도가 오지 않는 상황 -> 출발지, 출발시간에 대한 기준으로만 쿼리 작성
5. 사용자의 출발시간이 오지 않는 상황 -> 출발지, 도착지에 대한 기준으로만 쿼리 작성
6. 2가지 이상의 정보(예: 출발지 정보, 출발시간 등)가 오지 않는 상황은 예외 처리. -> "출발지, 도착지, 출발시간에 대한 정보를 올바르게 넣어주세요!"

- PartyGetCustomException: 500 -> 400으로 변경
- page,size 예외의 위치를 서비스단 -> 컨트롤러 validation으로 변경
- Future애너테이션으로 DTO에서 party방의 출발시간 검증 추가