### PR TITLE
[#26] fix: MemberNotFoundException이 404가 아닌 500 반환하는 버그 수정

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -10,13 +10,13 @@ import edu.kangwon.university.taxicarpool.email.exception.InvalidVerificationCod
 import edu.kangwon.university.taxicarpool.map.exception.KakaoApiParseException;
 import edu.kangwon.university.taxicarpool.member.exception.DuplicatedEmailException;
 import edu.kangwon.university.taxicarpool.member.exception.DuplicatedNicknameException;
-import edu.kangwon.university.taxicarpool.party.partyException.MemberNotFoundException;
+import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyFullException;
-import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
+import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -2,10 +2,10 @@ package edu.kangwon.university.taxicarpool.party;
 
 import edu.kangwon.university.taxicarpool.member.MemberEntity;
 import edu.kangwon.university.taxicarpool.member.MemberRepository;
+import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyCreateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyResponseDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyUpdateRequestDTO;
-import edu.kangwon.university.taxicarpool.party.partyException.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/MemberNotFoundException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/MemberNotFoundException.java
@@ -1,8 +1,0 @@
-package edu.kangwon.university.taxicarpool.party.partyException;
-
-public class MemberNotFoundException extends RuntimeException {
-
-    public MemberNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/taxi-carpool/src/test/java/edu/kangwon/university/taxicarpool/party/PartyServiceTest.java
+++ b/taxi-carpool/src/test/java/edu/kangwon/university/taxicarpool/party/PartyServiceTest.java
@@ -1,24 +1,26 @@
 package edu.kangwon.university.taxicarpool.party;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
 import edu.kangwon.university.taxicarpool.member.MemberEntity;
 import edu.kangwon.university.taxicarpool.member.MemberRepository;
+import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyCreateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyResponseDTO;
-import edu.kangwon.university.taxicarpool.party.partyException.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PartyServiceTest {
@@ -77,7 +79,8 @@ class PartyServiceTest {
             4
         );
 
-        mockMemberEntity = new MemberEntity("test@test.com", "password", "닉네임", edu.kangwon.university.taxicarpool.member.Gender.MALE);
+        mockMemberEntity = new MemberEntity("test@test.com", "password", "닉네임",
+            edu.kangwon.university.taxicarpool.member.Gender.MALE);
         mockMemberEntity.setEmail("test@test.com");
         mockMemberEntity.setNickname("테스트멤버");
         mockMemberEntity.setPassword("password");


### PR DESCRIPTION
- 중복된 MemberNotFoundException으로 인해 버그가 발생하였음.
- party 패키지의 MemberNotFoundException을 삭제 함.
- 모든MemberNotFoundException을 member 패키지에서 관리하도록 변경함.