### PR TITLE
[#32, 33] 컨트롤러의 validation, partyDelete오류 수정

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthService.java
@@ -111,11 +111,12 @@ public class AuthService {
         if (optionalToken.isPresent()) {
             RefreshTokenEntity tokenEntity = optionalToken.get();
 
-            // 만료시간을 현재 시각으로 세팅하여 무효화시키기 (걍 레포지토리에서 delete해도 되긴함)
+            // 만료시간을 현재 시각으로 세팅하여 리프레쉬 토큰 무효화시키기 (걍 레포지토리에서 delete해도 되긴함)
             tokenEntity.setExpiryDate(LocalDateTime.now());
             refreshTokenRepository.save(tokenEntity);
         } else {
-            throw new TokenInvalidException("토큰없는 로그아웃입니다. 재로그인 후 로그아웃 해주세요.");
+            // 토큰없는 로그아웃
+            throw new TokenInvalidException("재로그인 후 로그아웃 해주세요.");
         }
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LoginDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LoginDTO.java
@@ -8,11 +8,11 @@ public class LoginDTO {
     // 로그인 요청 DTO
     public static class LoginRequest {
 
-        @NotBlank
+        @NotBlank(message = "이메일이 공백일 수 없습니다")
         @Email
         private String email;
 
-        @NotBlank
+        @NotBlank(message = "패스워드가 공백일 수 없습니다")
         private String password;
 
         public LoginRequest() {

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LoginDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LoginDTO.java
@@ -2,6 +2,7 @@ package edu.kangwon.university.taxicarpool.auth;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class LoginDTO {
 
@@ -80,6 +81,7 @@ public class LoginDTO {
     //리프래쉬 토큰으로 액세스 토큰 재발급 요청 DTO
     public static class RefreshRequestDTO {
 
+        @NotNull
         private String refreshToken;
 
         public RefreshRequestDTO() {

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LogoutDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LogoutDTO.java
@@ -7,8 +7,8 @@ public class LogoutDTO {
 
     public static class LogoutRequestDTO {
 
-        @NotBlank
-        @Email
+        @NotBlank(message = "이메일 공백 오류")
+        @Email(message = "이메일 형식을 지켜주세요.")
         private String email;
 
         public LogoutRequestDTO() {

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -51,12 +51,13 @@ public class GlobalExceptionHandler {
     }
 
     // 빈 JSON이나 잘못된 형식으로 인한 예외 처리
-    @ExceptionHandler({MethodArgumentNotValidException.class,
-        HttpMessageNotReadableException.class})
-    public ResponseEntity<Map<String, String>> handleValidationExceptions(Exception ex) {
-        Map<String, String> errorResponse = new HashMap<>();
-        errorResponse.put("message", "로그인 형식을 올바르게 보내주세요.");
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(
+        MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+            errors.put(error.getField(), error.getDefaultMessage()));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
     @ExceptionHandler(TokenInvalidException.class)

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -19,11 +19,11 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomExc
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -223,6 +223,26 @@ public class GlobalExceptionHandler {
             ex.getMessage(),
             request.getRequestURI()
         );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponseDTO> handleConstraintViolationException(
+        ConstraintViolationException ex,
+        HttpServletRequest request
+    ) {
+        String errorMessage = ex.getConstraintViolations()
+            .stream()
+            .map(v -> v.getMessage())
+            .findFirst()
+            .orElse("잘못된 요청입니다.");
+
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.BAD_REQUEST.value(),
+            errorMessage,
+            request.getRequestURI()
+        );
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/party")
+@Validated
 public class PartyController {
 
     private final PartyService partyService;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
@@ -260,6 +260,7 @@ public class PartyDTO {
     // creatorMemberId 필드 존재, hostMemberId필드 삭제 -> creatorMemberId사용의 강제를 위해.
     public static class PartyCreateRequestDTO {
 
+        @NotNull
         @NotBlank(message = "파티 이름은 필수입니다.")
         @Size(max = 20, message = "이름은 공백 포함 최대 20글자까지 가능합니다.")
         private String name;
@@ -281,13 +282,16 @@ public class PartyDTO {
 
         private boolean destinationChangeIn5Minutes;
 
+        @NotNull
         @Future(message = "출발 시간은 현재 시간보다 이후여야 합니다.")
-        @NotNull(message = "출발 시간 입력은 필수입니다.")
+        @NotBlank(message = "출발 시간 입력은 필수입니다.")
         private LocalDateTime startDateTime;
 
+        @NotNull
         @NotBlank(message = "출발지 입력은 필수입니다.")
         private String startLocation;
 
+        @NotNull
         @NotBlank(message = "목적지 입력은 필수입니다.")
         private String endLocation;
 
@@ -503,6 +507,7 @@ public class PartyDTO {
     // UpdateRequestDTO에는 현재 인원수에 대한 필드가 없음 -> 파티의 인원수에 관한 로직은 무조건 join/leave 엔트포인트 사용을 강제를 위해
     public static class PartyUpdateRequestDTO {
 
+        @NotNull
         @NotBlank(message = "파티 이름은 필수입니다.")
         private String name;
 
@@ -522,12 +527,15 @@ public class PartyDTO {
 
         private boolean destinationChangeIn5Minutes;
 
-        @NotNull(message = "출발 시간 입력은 필수입니다.")
+        @NotNull
+        @NotBlank(message = "출발 시간 입력은 필수입니다.")
         private LocalDateTime startDateTime;
 
+        @NotNull
         @NotBlank(message = "출발지 입력은 필수입니다.")
         private String startLocation;
 
+        @NotNull
         @NotBlank(message = "목적지 입력은 필수입니다.")
         private String endLocation;
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
@@ -260,7 +260,6 @@ public class PartyDTO {
     // creatorMemberId 필드 존재, hostMemberId필드 삭제 -> creatorMemberId사용의 강제를 위해.
     public static class PartyCreateRequestDTO {
 
-        @NotNull
         @NotBlank(message = "파티 이름은 필수입니다.")
         @Size(max = 20, message = "이름은 공백 포함 최대 20글자까지 가능합니다.")
         private String name;
@@ -282,16 +281,13 @@ public class PartyDTO {
 
         private boolean destinationChangeIn5Minutes;
 
-        @NotNull
         @Future(message = "출발 시간은 현재 시간보다 이후여야 합니다.")
-        @NotBlank(message = "출발 시간 입력은 필수입니다.")
+        @NotNull(message = "출발 시간 입력은 필수입니다.")
         private LocalDateTime startDateTime;
 
-        @NotNull
         @NotBlank(message = "출발지 입력은 필수입니다.")
         private String startLocation;
 
-        @NotNull
         @NotBlank(message = "목적지 입력은 필수입니다.")
         private String endLocation;
 
@@ -507,7 +503,6 @@ public class PartyDTO {
     // UpdateRequestDTO에는 현재 인원수에 대한 필드가 없음 -> 파티의 인원수에 관한 로직은 무조건 join/leave 엔트포인트 사용을 강제를 위해
     public static class PartyUpdateRequestDTO {
 
-        @NotNull
         @NotBlank(message = "파티 이름은 필수입니다.")
         private String name;
 
@@ -527,15 +522,12 @@ public class PartyDTO {
 
         private boolean destinationChangeIn5Minutes;
 
-        @NotNull
-        @NotBlank(message = "출발 시간 입력은 필수입니다.")
+        @NotNull(message = "출발 시간 입력은 필수입니다.")
         private LocalDateTime startDateTime;
 
-        @NotNull
         @NotBlank(message = "출발지 입력은 필수입니다.")
         private String startLocation;
 
-        @NotNull
         @NotBlank(message = "목적지 입력은 필수입니다.")
         private String endLocation;
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
@@ -15,6 +15,8 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
 
     Optional<PartyEntity> findById(Long partyId);
 
+    Optional<PartyEntity> findByIdAndIsDeletedFalse(Long partyId);
+
     // 모든 파라미터가 온 경우
     @Query(value = "SELECT p.*, " +
         " (ST_Distance_Sphere(" +

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -124,11 +124,10 @@ public class PartyService {
                 userDestinationLat,
                 pageable);
 
-        } else {
-            throw new PartyGetCustomException("출발지, 도착지, 출발시간에 대한 정보를 올바르게 넣어주세요!");
         }
 
-        return partyEntities.map(partyMapper::convertToResponseDTO);
+        throw new PartyGetCustomException("출발지, 도착지, 출발시간에 대한 정보를 올바르게 넣어주세요!");
+
     }
 
     @Transactional

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -175,7 +175,7 @@ public class PartyService {
 
     @Transactional
     public Map<String, Object> deleteParty(Long partyId, Long memberId) {
-        PartyEntity partyEntity = partyRepository.findById(partyId)
+        PartyEntity partyEntity = partyRepository.findByIdAndIsDeletedFalse(partyId)
             .orElseThrow(() -> new PartyNotFoundException("해당 파티가 존재하지 않습니다."));
         if (!partyEntity.getHostMemberId().equals(memberId)) {
             throw new UnauthorizedHostAccessException("호스트만 삭제할 수 있습니다.");


### PR DESCRIPTION
### 컨트롤러의 validation이 정상적으로 동작하지 않음. 

- https://github.com/capstoneDesign-taxiCarpool/team_BE/issues/32
- @min(value = 0, message = "페이지 번호는 0 이상이어야 합니다." 와 같이 정의해둔 validation이 정상적으로 예외처리에 잡히지 않고, 500오류를 발생시킴.
- dto에 해둔 validation은 controller이전에 요청에서 걸러지기 때문에, 글로벌 핸들러를 거치지 않는 선에서 예외가 발생함.
- 그러나 controller에 붙여놓은 validation은 컨트롤러에서 예외를 잡기 때문에 예외가 발생할 경우, 글로벌 핸들러를 거침. 고로 글로벌 핸들러에 @RequestParam에 대한 유효성 검증실패 시 발생하는`ConstraintViolationException`를 정의해두지 않으면 글로벌 핸들러 가장 아래의 범용 예외처리에 의해 예외가 처리됨.
- 고로 글로벌 핸들러에 `ConstraintViolationException`을 정의해두면 됨.
- 그런데 진호님이 같은 오류를 겪고 있으나, `MethodArgumentNotValidException`를 만들어두셔서, `ConstraintViolationException`를 만듦.

### 삭제한 party방의 id를 그대로 삭제요청을 보냈을 때 200ok가 나오는 문제

- https://github.com/capstoneDesign-taxiCarpool/team_BE/issues/33
- 현재 party방의 delete는 softDelete이다.
- 고로 findById()를 통해 삭제 여부를 확인하면 안 된다.
- findByIdAndIsDeletedFalse()메서드를 통해 삭제 여부를 확인하자.