### PR TITLE
[#35,36,37,38] 오류 수정

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import edu.kangwon.university.taxicarpool.member.exception.DuplicatedEmailExcept
 import edu.kangwon.university.taxicarpool.member.exception.DuplicatedNicknameException;
 import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNameException;
+import edu.kangwon.university.taxicarpool.party.partyException.MemberAlreadyInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
@@ -268,11 +269,24 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicatedPartyNameException.class)
     public ResponseEntity<ErrorResponseDTO> handleDuplicatedPartyNameException(
         DuplicatedPartyNameException ex, HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(),
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.CONFLICT.value(),
             ex.getMessage(),
             request.getRequestURI());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
+
+    @ExceptionHandler(MemberAlreadyInPartyException.class)
+    public ResponseEntity<ErrorResponseDTO> handleMemberAlreadyInPartyException(
+        MemberAlreadyInPartyException ex, HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.CONFLICT.value(),
+            ex.getMessage(),
+            request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
 
     // 그 외 잡히지 않은 모든 예외에 대한 전역 핸들러
     @ExceptionHandler(Exception.class)

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import edu.kangwon.university.taxicarpool.map.exception.KakaoApiParseException;
 import edu.kangwon.university.taxicarpool.member.exception.DuplicatedEmailException;
 import edu.kangwon.university.taxicarpool.member.exception.DuplicatedNicknameException;
 import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
+import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNameException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
@@ -262,6 +263,15 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(DuplicatedPartyNameException.class)
+    public ResponseEntity<ErrorResponseDTO> handleDuplicatedPartyNameException(
+        DuplicatedPartyNameException ex, HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.CONFLICT.value(),
+            ex.getMessage(),
+            request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
     // 그 외 잡히지 않은 모든 예외에 대한 전역 핸들러

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -16,7 +16,6 @@ import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNa
 import edu.kangwon.university.taxicarpool.party.partyException.MemberAlreadyInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
-import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyFullException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
@@ -122,15 +121,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PartyAlreadyDeletedException.class)
     public ResponseEntity<ErrorResponseDTO> handlePartyAlreadyDeletedException(
         PartyAlreadyDeletedException ex,
-        HttpServletRequest request) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.GONE.value(),
-            ex.getMessage(),
-            request.getRequestURI());
-        return ResponseEntity.status(HttpStatus.GONE).body(errorResponse);
-    }
-
-    @ExceptionHandler(PartyEmptyException.class)
-    public ResponseEntity<ErrorResponseDTO> handlePartyEmptyException(PartyEmptyException ex,
         HttpServletRequest request) {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(HttpStatus.GONE.value(),
             ex.getMessage(),

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
@@ -17,6 +17,8 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
 
     Optional<PartyEntity> findByIdAndIsDeletedFalse(Long partyId);
 
+    boolean existsByNameAndIsDeletedFalse(String name);
+
     // 모든 파라미터가 온 경우
     @Query(value = "SELECT p.*, " +
         " (ST_Distance_Sphere(" +

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
@@ -34,10 +34,10 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
         countQuery = "SELECT COUNT(*) FROM party p",
         nativeQuery = true)
     Page<PartyEntity> findCustomPartyList(
-        @Param("userDepartureLng") double userDepartureLng,
-        @Param("userDepartureLat") double userDepartureLat,
-        @Param("userDestinationLng") double userDestinationLng,
-        @Param("userDestinationLat") double userDestinationLat,
+        @Param("userDepartureLng") Double userDepartureLng,
+        @Param("userDepartureLat") Double userDepartureLat,
+        @Param("userDestinationLng") Double userDestinationLng,
+        @Param("userDestinationLat") Double userDestinationLat,
         @Param("userDepartureTime") LocalDateTime userDepartureTime,
         Pageable pageable
     );
@@ -54,8 +54,8 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
         countQuery = "SELECT COUNT(*) FROM party p",
         nativeQuery = true)
     Page<PartyEntity> findCustomPartyList(
-        @Param("userDestinationLng") double userDestinationLng,
-        @Param("userDestinationLat") double userDestinationLat,
+        @Param("userDestinationLng") Double userDestinationLng,
+        @Param("userDestinationLat") Double userDestinationLat,
         @Param("userDepartureTime") LocalDateTime userDepartureTime,
         Pageable pageable
     );
@@ -77,10 +77,10 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
         countQuery = "SELECT COUNT(*) FROM party p",
         nativeQuery = true)
     Page<PartyEntity> findCustomPartyList(
-        @Param("userDepartureLng") double userDepartureLng,
-        @Param("userDepartureLat") double userDepartureLat,
-        @Param("userDestinationLng") double userDestinationLng,
-        @Param("userDestinationLat") double userDestinationLat,
+        @Param("userDepartureLng") Double userDepartureLng,
+        @Param("userDepartureLat") Double userDepartureLat,
+        @Param("userDestinationLng") Double userDestinationLng,
+        @Param("userDestinationLat") Double userDestinationLat,
         Pageable pageable
     );
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyRepository.java
@@ -19,6 +19,8 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
 
     boolean existsByNameAndIsDeletedFalse(String name);
 
+    Page<PartyEntity> findAllByIsDeletedFalse(Pageable pageable);
+
     // 모든 파라미터가 온 경우
     @Query(value = "SELECT p.*, " +
         " (ST_Distance_Sphere(" +
@@ -32,8 +34,9 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
         " )" +
         " ) AS total_distance " +
         "FROM party p " +
+        "WHERE p.is_deleted = false " +
         "ORDER BY total_distance ASC, ABS(TIMESTAMPDIFF(MINUTE, p.start_date_time, :userDepartureTime)) ASC",
-        countQuery = "SELECT COUNT(*) FROM party p",
+        countQuery = "SELECT COUNT(*) FROM party p WHERE p.is_deleted = false",
         nativeQuery = true)
     Page<PartyEntity> findCustomPartyList(
         @Param("userDepartureLng") Double userDepartureLng,
@@ -52,8 +55,9 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
         +
         " ) AS total_distance " +
         "FROM party p " +
+        "WHERE p.is_deleted = false " +
         "ORDER BY total_distance ASC, ABS(TIMESTAMPDIFF(MINUTE, p.start_date_time, :userDepartureTime)) ASC",
-        countQuery = "SELECT COUNT(*) FROM party p",
+        countQuery = "SELECT COUNT(*) FROM party p WHERE p.is_deleted = false",
         nativeQuery = true)
     Page<PartyEntity> findCustomPartyList(
         @Param("userDestinationLng") Double userDestinationLng,
@@ -75,8 +79,9 @@ public interface PartyRepository extends JpaRepository<PartyEntity, Long> {
         " )" +
         " ) AS total_distance " +
         "FROM party p " +
+        "WHERE p.is_deleted = false " +
         "ORDER BY total_distance ASC",
-        countQuery = "SELECT COUNT(*) FROM party p",
+        countQuery = "SELECT COUNT(*) FROM party p WHERE p.is_deleted = false",
         nativeQuery = true)
     Page<PartyEntity> findCustomPartyList(
         @Param("userDepartureLng") Double userDepartureLng,

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -69,6 +69,10 @@ public class PartyService {
 
         Pageable pageable = PageRequest.of(page, size);
 
+        if (userDepartureTime != null && userDepartureTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("출발 시간은 현재 시간보다 이후여야 합니다.");
+        }
+
         // 각 그룹(출발지, 도착지, 출발시간)의 누락 여부 확인
         boolean missingDeparture = (userDepartureLng == null || userDepartureLat == null);
         boolean missingDestination = (userDestinationLng == null || userDestinationLat == null);

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -15,7 +15,7 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyFullExceptio
 import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -47,14 +47,14 @@ public class PartyService {
     }
 
     public PartyResponseDTO getParty(Long partyId) {
-        PartyEntity partyEntity = partyRepository.findById(partyId)
+        PartyEntity partyEntity = partyRepository.findByIdAndIsDeletedFalse(partyId)
             .orElseThrow(() -> new PartyNotFoundException("해당 파티가 존재하지 않습니다."));
         return partyMapper.convertToResponseDTO(partyEntity);
     }
 
     public Page<PartyResponseDTO> getPartyList(Integer page, Integer size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, "createdAt"));
-        Page<PartyEntity> partyEntities = partyRepository.findAll(pageable);
+        Page<PartyEntity> partyEntities = partyRepository.findAllByIsDeletedFalse(pageable);
         return partyEntities.map(partyMapper::convertToResponseDTO);
     }
 
@@ -166,7 +166,7 @@ public class PartyService {
     @Transactional
     public PartyResponseDTO updateParty(Long partyId, Long memberId,
         PartyUpdateRequestDTO updateRequestDTO) {
-        PartyEntity existingPartyEntity = partyRepository.findById(partyId)
+        PartyEntity existingPartyEntity = partyRepository.findByIdAndIsDeletedFalse(partyId)
             .orElseThrow(() -> new PartyNotFoundException("해당 파티가 존재하지 않습니다."));
 
         if (!existingPartyEntity.getHostMemberId().equals(memberId)) {
@@ -200,7 +200,7 @@ public class PartyService {
     // 멤버가 파티방의 멤버로 참가하는 로직의 메서드
     @Transactional
     public PartyResponseDTO joinParty(Long partyId, Long memberId) {
-        PartyEntity party = partyRepository.findById(partyId)
+        PartyEntity party = partyRepository.findByIdAndIsDeletedFalse(partyId)
             .orElseThrow(() -> new PartyNotFoundException("해당 파티가 존재하지 않습니다."));
         if (party.isDeleted()) {
             throw new PartyAlreadyDeletedException("이미 삭제된 파티입니다.");
@@ -227,9 +227,9 @@ public class PartyService {
         return partyMapper.convertToResponseDTO(savedParty);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = PartyEmptyException.class)
     public PartyResponseDTO leaveParty(Long partyId, Long memberId) {
-        PartyEntity party = partyRepository.findById(partyId)
+        PartyEntity party = partyRepository.findByIdAndIsDeletedFalse(partyId)
             .orElseThrow(() -> new PartyNotFoundException("해당 파티가 존재하지 않습니다."));
         MemberEntity member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException("해당 멤버가 존재하지 않습니다."));
@@ -253,6 +253,7 @@ public class PartyService {
         } else {
             // 앱의 플로우상 마지막으로 떠나는 멤버가 호스트일수밖에 없어서, 해당 코드가 필요하지 않을 것 같긴한데, 혹시 몰라서 일단 추가해둠.
             party.setDeleted(true);
+            partyRepository.saveAndFlush(party);
             throw new PartyEmptyException("파티방의 모든 멤버가 떠나여, 파티방이 삭제되었습니다.");
         }
 
@@ -262,6 +263,7 @@ public class PartyService {
             if (remaining.isEmpty()) {
                 // 아무도 없으면 삭제 처리
                 party.setDeleted(true);
+                partyRepository.saveAndFlush(party);
                 throw new PartyEmptyException("파티방의 모든 멤버가 떠나여, 파티방이 삭제되었습니다.");
             } else {
                 // 첫 멤버를 새 호스트로(호스트 제외하고 가장 빨리 들어온 멤버)

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -10,7 +10,6 @@ import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNa
 import edu.kangwon.university.taxicarpool.party.partyException.MemberAlreadyInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
-import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyFullException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -7,6 +7,7 @@ import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyCreateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyResponseDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyUpdateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNameException;
+import edu.kangwon.university.taxicarpool.party.partyException.MemberAlreadyInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
@@ -206,6 +207,10 @@ public class PartyService {
         }
         MemberEntity member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException("해당 멤버가 존재하지 않습니다."));
+
+        if (party.getMemberEntities().contains(member)) {
+            throw new MemberAlreadyInPartyException("이미 이 파티에 참여한 멤버입니다.");
+        }
 
         party.getMemberEntities().add(member);
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -231,7 +231,7 @@ public class PartyService {
         return partyMapper.convertToResponseDTO(savedParty);
     }
 
-    @Transactional(noRollbackFor = PartyEmptyException.class)
+    @Transactional
     public PartyResponseDTO leaveParty(Long partyId, Long memberId) {
         PartyEntity party = partyRepository.findByIdAndIsDeletedFalse(partyId)
             .orElseThrow(() -> new PartyNotFoundException("해당 파티가 존재하지 않습니다."));
@@ -257,8 +257,7 @@ public class PartyService {
         } else {
             // 앱의 플로우상 마지막으로 떠나는 멤버가 호스트일수밖에 없어서, 해당 코드가 필요하지 않을 것 같긴한데, 혹시 몰라서 일단 추가해둠.
             party.setDeleted(true);
-            partyRepository.saveAndFlush(party);
-            throw new PartyEmptyException("파티방의 모든 멤버가 떠나여, 파티방이 삭제되었습니다.");
+            return partyMapper.convertToResponseDTO(party);
         }
 
         // 호스트인 멤버가 파티를 떠나려고 할 때의 로직.
@@ -267,8 +266,7 @@ public class PartyService {
             if (remaining.isEmpty()) {
                 // 아무도 없으면 삭제 처리
                 party.setDeleted(true);
-                partyRepository.saveAndFlush(party);
-                throw new PartyEmptyException("파티방의 모든 멤버가 떠나여, 파티방이 삭제되었습니다.");
+                return partyMapper.convertToResponseDTO(party);
             } else {
                 // 첫 멤버를 새 호스트로(호스트 제외하고 가장 빨리 들어온 멤버)
                 MemberEntity nextHost = remaining.get(0);

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -6,6 +6,7 @@ import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundExcepti
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyCreateRequestDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyResponseDTO;
 import edu.kangwon.university.taxicarpool.party.PartyDTO.PartyUpdateRequestDTO;
+import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNameException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyEmptyException;
@@ -133,6 +134,10 @@ public class PartyService {
 
     @Transactional
     public PartyResponseDTO createParty(PartyCreateRequestDTO createRequestDTO) {
+
+        if (partyRepository.existsByNameAndIsDeletedFalse(createRequestDTO.getName())) {
+            throw new DuplicatedPartyNameException("같은 이름의 파티가 이미 존재합니다.");
+        }
 
         PartyEntity partyEntity = partyMapper.convertToEntity(createRequestDTO);
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -50,7 +51,7 @@ public class PartyService {
     }
 
     public Page<PartyResponseDTO> getPartyList(Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, "createdAt"));
         Page<PartyEntity> partyEntities = partyRepository.findAll(pageable);
         return partyEntities.map(partyMapper::convertToResponseDTO);
     }
@@ -87,7 +88,7 @@ public class PartyService {
             throw new PartyGetCustomException("출발지, 도착지, 출발시간에 대한 정보 중 2개 이상 넣어주세요!");
         }
 
-        Page<PartyEntity> partyEntities;
+        Page<PartyEntity> partyEntities = null;
 
         // 모든 정보가 있는 경우
         if (!missingDeparture && !missingDestination && !missingDepartureTime) {
@@ -126,7 +127,7 @@ public class PartyService {
 
         }
 
-        throw new PartyGetCustomException("출발지, 도착지, 출발시간에 대한 정보를 올바르게 넣어주세요!");
+        return partyEntities.map(partyMapper::convertToResponseDTO);
 
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/DuplicatedPartyNameException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/DuplicatedPartyNameException.java
@@ -1,0 +1,7 @@
+package edu.kangwon.university.taxicarpool.party.partyException;
+
+public class DuplicatedPartyNameException extends RuntimeException {
+    public DuplicatedPartyNameException(String message) {
+        super(message);
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/MemberAlreadyInPartyException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/MemberAlreadyInPartyException.java
@@ -1,0 +1,8 @@
+package edu.kangwon.university.taxicarpool.party.partyException;
+
+public class MemberAlreadyInPartyException extends RuntimeException{
+    public MemberAlreadyInPartyException(String message) {
+        super(message);
+    }
+
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/PartyEmptyException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/PartyEmptyException.java
@@ -1,8 +1,0 @@
-package edu.kangwon.university.taxicarpool.party.partyException;
-
-public class PartyEmptyException extends RuntimeException {
-
-    public PartyEmptyException(String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
- partyCreate에서 이름이 같은 파티방은 생성이 안 되도록 수정. -> Repository에 탐색하는 메서드 하나 만들어두고, 이를 이용한 검증 추가.
- joinParty에서 같은 멤버로 2번 요청 보내면 같은 멤버가 하나의 party방에 2명처럼 참여됨. ->` party.getMemberEntities().contains(member)`으로 검증
- leaveParty(마지막 멤버 나갔을 경우)나 delete를 한 뒤에, get, getList요청 해보면 삭제된 것이라고 나와야함. -> findById에서 findByIdAndIsDeletedFalse메서드로 변경. 또한 트랜잭션 끝나기전에 예외가 처리되면 이전 로직들 다 롤백된다. 그래서 save()말고 saveAndFlush()로 강제로 넣는 것과 동시에 그냥 트랜잭션을 사용하지 말고, `@Transactional` (noRollbackFor = PartyEmptyException.class)으로 롤백을 피해가야한다. 또한 이 트랜잭션을 사용할 때는 import를 jakarta의 트랜잭션을 사용함녀 안 되고, springframework의 트랜잭션을 사용해야한다.
- getCustomPartyList에서 사용자의 출발시간이 현재 시간보다 뒤의 시간인지 검증 넣어야함. -> .isBefore(LocalDateTime.now())으로 검