### PR TITLE
[#43] config에 토큰 인증 없이 허용가능한 경로 추가

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/SecurityConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/SecurityConfig.java
@@ -37,7 +37,14 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable()) // 필요에 따라 설정해야한다고 함.
             .authorizeHttpRequests(auth -> auth
                 // 회원가입/로그인 엔드포인트는 인증 없이 접근 가능하게
-                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers(
+                    "/",                        // 루트
+                    "/api/auth/**",             // 회원가입, 로그인
+                    "/swagger-ui/**",           // 스웨거 UI리소스
+                    "/v3/api-docs/**",          // 스웨거 API 문서
+                    "/swagger-resources/**",    // 스웨거 리소스
+                    "/webjars/**"               // 스웨거 관련 정적 리소스
+                ).permitAll()
                 // 그 외 모든 요청은 인증 필요
                 .anyRequest().authenticated()
             )

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/SecurityConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/",                        // 루트
                     "/api/auth/**",             // 회원가입, 로그인
+                    "/api/email/**",            // 이메일 인증
                     "/swagger-ui/**",           // 스웨거 UI리소스
                     "/v3/api-docs/**",          // 스웨거 API 문서
                     "/swagger-resources/**",    // 스웨거 리소스

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/init/DataInitializer.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/init/DataInitializer.java
@@ -1,0 +1,35 @@
+package edu.kangwon.university.taxicarpool.init;
+
+import edu.kangwon.university.taxicarpool.member.Gender;
+import edu.kangwon.university.taxicarpool.member.MemberRepository;
+import edu.kangwon.university.taxicarpool.member.MemberService;
+import edu.kangwon.university.taxicarpool.member.dto.MemberCreateDTO;
+import edu.kangwon.university.taxicarpool.party.PartyRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    private final MemberService memberService;
+
+    public DataInitializer(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Override
+    public void run(String... args) {
+
+        // 초기데이터 넣을 때, 원래 signUp을 해야하지만, 이메일 인증 과정을
+        // 우회하기 위해 초기 멤버데이터 넣기.
+        MemberCreateDTO member1 = new MemberCreateDTO("user1@kangwon.ac.kr", "password1", "유저1", Gender.MALE);
+        MemberCreateDTO member2 = new MemberCreateDTO("user2@kangwon.ac.kr", "password2", "유저2", Gender.FEMALE);
+        MemberCreateDTO member3 = new MemberCreateDTO("user3@kangwon.ac.kr", "password3", "유저3", Gender.MALE);
+
+        memberService.createMember(member1);
+        memberService.createMember(member2);
+        memberService.createMember(member3);
+
+        System.out.println("===== 초기 데이터 로딩 완료 =====");
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyDTO.java
@@ -13,7 +13,6 @@ import java.util.List;
 public class PartyDTO {
 
     public static class PartyResponseDTO {
-
         private Long id;
 
         private String name;


### PR DESCRIPTION
- 기존에는 /api/auth/**만 permitAll
- 루트 경로와 스웨거 관련 경로도 permitAll로 변경
- 그 외의 init데이터(memberCreate) 추가