### PR TITLE
chore: 빌드 과정 중의 테스트를 위한 DB추가

### DIFF
--- a/taxi-carpool/build.gradle
+++ b/taxi-carpool/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/taxi-carpool/src/test/java/edu/kangwon/university/taxicarpool/KangwonTaxiCarpoolApplicationTests.java
+++ b/taxi-carpool/src/test/java/edu/kangwon/university/taxicarpool/KangwonTaxiCarpoolApplicationTests.java
@@ -1,9 +1,11 @@
 package edu.kangwon.university.taxicarpool;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 class KangwonTaxiCarpoolApplicationTests {
 
 	@Test


### PR DESCRIPTION
- 빌드 과정 중의 테스트 단계에서는 배포 인스턴스 서버를 위한 MySQL같은 DB를 사용하는 것이 불가능하기 때문에 H2를 테스트에만 사용한다는 의존성을 추가하였습니다.