### PR TITLE
빌드중의 test를 위한 DB설정

### DIFF
--- a/taxi-carpool/build.gradle
+++ b/taxi-carpool/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/taxi-carpool/build.gradle
+++ b/taxi-carpool/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	runtimeOnly 'com.h2database:h2'
+	implementation 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/taxi-carpool/src/main/resources/application.properties
+++ b/taxi-carpool/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 spring.application.name=Kangwon Taxi Carpool
+
+# env
 spring.config.import=optional:file:.env[.properties]
+
+# email
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${EMAIL_VERIFICATION_GOOGLE_ID}
@@ -9,4 +13,14 @@ spring.mail.properties.mail.smtp.debug=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 email.address=${EMAIL_VERIFICATION_GOOGLE_ADDRESS}
 email.name=KNU Carpool
+
+# kakaoAPI
 kakao.api.key=${KAKAO_APP_REST_KEY}
+
+#DB
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.show-sql=true

--- a/taxi-carpool/src/test/java/edu/kangwon/university/taxicarpool/KangwonTaxiCarpoolApplicationTests.java
+++ b/taxi-carpool/src/test/java/edu/kangwon/university/taxicarpool/KangwonTaxiCarpoolApplicationTests.java
@@ -1,9 +1,11 @@
 package edu.kangwon.university.taxicarpool;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 class KangwonTaxiCarpoolApplicationTests {
 
 	@Test


### PR DESCRIPTION
- 빌드 과정 중의 테스트 단계에서는 배포 인스턴스 서버를 위한 MySQL같은 DB를 사용하는 것이 불가능하기 때문에 H2를 테스트에만 사용한다는 의존성을 추가하였습니다.
- 또한 testApplication파일에 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY) 애너테이션을 같은 목적으로 추가하였습니다. 