### PR TITLE
fix(deploy): 워크플로우 실행 시 ec2에 환경변수가 전달되지 않는 버그 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,17 +61,18 @@ jobs:
         ssh -i key.pem ec2-user@${{ secrets.EC2_HOST }} << 'EOF'
         set -eux
         pkill -f java || true
-        nohup \
-          SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }} \
-          SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }} \
-          SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }} \
-          EMAIL_VERIFICATION_GOOGLE_ID=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ID }} \
-          EMAIL_VERIFICATION_GOOGLE_PW=${{ secrets.EMAIL_VERIFICATION_GOOGLE_PW }} \
-          EMAIL_VERIFICATION_GOOGLE_ADDRESS=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ADDRESS }} \
-          KAKAO_APP_REST_KEY=${{ secrets.KAKAO_APP_REST_KEY }} \
-          JWT_SECRET=${{ secrets.JWT_SECRET }} \
-          java -Dspring.profiles.active=prod \
-               -jar /home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar \
+    
+        export SPRING_DATASOURCE_URL='${{ secrets.SPRING_DATASOURCE_URL }}'
+        export SPRING_DATASOURCE_USERNAME='${{ secrets.SPRING_DATASOURCE_USERNAME }}'
+        export SPRING_DATASOURCE_PASSWORD='${{ secrets.SPRING_DATASOURCE_PASSWORD }}'
+        export EMAIL_VERIFICATION_GOOGLE_ID='${{ secrets.EMAIL_VERIFICATION_GOOGLE_ID }}'
+        export EMAIL_VERIFICATION_GOOGLE_PW='${{ secrets.EMAIL_VERIFICATION_GOOGLE_PW }}'
+        export EMAIL_VERIFICATION_GOOGLE_ADDRESS='${{ secrets.EMAIL_VERIFICATION_GOOGLE_ADDRESS }}'
+        export KAKAO_APP_REST_KEY='${{ secrets.KAKAO_APP_REST_KEY }}'
+        export JWT_SECRET='${{ secrets.JWT_SECRET }}'
+        
+        nohup java -Dspring.profiles.active=prod \
+          -jar /home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar \
           > /home/ec2-user/logs/log.txt 2>&1 &
         EOF
       working-directory: ./taxi-carpool

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,19 +55,23 @@ jobs:
     - name: Upload JAR to EC2
       run: scp -i key.pem build/libs/taxi-carpool-0.0.1-SNAPSHOT.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar
       working-directory: ./taxi-carpool
-    
+
     - name: Start Spring App on EC2
       run: |
-        ssh -i key.pem ec2-user@${{ secrets.EC2_HOST }} "
-          pkill -f 'java' || true &&
-          nohup \
-            SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }} \
-            SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }} \
-            SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }} \
-            EMAIL_VERIFICATION_GOOGLE_ID=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ID }} \
-            EMAIL_VERIFICATION_GOOGLE_PW=${{ secrets.EMAIL_VERIFICATION_GOOGLE_PW }} \
-            EMAIL_VERIFICATION_GOOGLE_ADDRESS=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ADDRESS }} \
-            KAKAO_APP_REST_KEY=${{ secrets.KAKAO_APP_REST_KEY }} \
-            JWT_SECRET=${{ secrets.JWT_SECRET }} \
-            java -Dspring.profiles.active=prod -jar /home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar > /home/ec2-user/logs/log.txt 2>&1 &"
+        ssh -i key.pem ec2-user@${{ secrets.EC2_HOST }} << 'EOF'
+        set -eux
+        pkill -f java || true
+        nohup \
+          SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }} \
+          SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }} \
+          SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }} \
+          EMAIL_VERIFICATION_GOOGLE_ID=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ID }} \
+          EMAIL_VERIFICATION_GOOGLE_PW=${{ secrets.EMAIL_VERIFICATION_GOOGLE_PW }} \
+          EMAIL_VERIFICATION_GOOGLE_ADDRESS=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ADDRESS }} \
+          KAKAO_APP_REST_KEY=${{ secrets.KAKAO_APP_REST_KEY }} \
+          JWT_SECRET=${{ secrets.JWT_SECRET }} \
+          java -Dspring.profiles.active=prod \
+               -jar /home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar \
+          > /home/ec2-user/logs/log.txt 2>&1 &
+        EOF
       working-directory: ./taxi-carpool


### PR DESCRIPTION
```
ssh -i key.pem ec2-user@${{ secrets.EC2_HOST }} "
          pkill -f 'java' || true &&
          nohup \
            SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }} \
            SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }} \
            SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }} \
            EMAIL_VERIFICATION_GOOGLE_ID=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ID }} \
            EMAIL_VERIFICATION_GOOGLE_PW=${{ secrets.EMAIL_VERIFICATION_GOOGLE_PW }} \
            EMAIL_VERIFICATION_GOOGLE_ADDRESS=${{ secrets.EMAIL_VERIFICATION_GOOGLE_ADDRESS }} \
            KAKAO_APP_REST_KEY=${{ secrets.KAKAO_APP_REST_KEY }} \
            JWT_SECRET=${{ secrets.JWT_SECRET }} \
            java -Dspring.profiles.active=prod -jar /home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar > /home/ec2-user/logs/log.txt 2>&1 &"
```

- 위 처럼 워크플로우 작성 시 로컬 셸이 한 줄 씩 합성하지 못하거나, 원격 셸로 전달 시에 백슬래시가 남을 가능성이 존재함.

- 따라서 이를 다음과 같이 here-doc 을 이용하여 한 번에 원격 셸로 전달하도록 변경 함.
```
ssh -i key.pem ec2-user@${{ secrets.EC2_HOST }} << 'EOF'
        set -eux
        pkill -f java || true
    
        export SPRING_DATASOURCE_URL='${{ secrets.SPRING_DATASOURCE_URL }}'
        export SPRING_DATASOURCE_USERNAME='${{ secrets.SPRING_DATASOURCE_USERNAME }}'
        export SPRING_DATASOURCE_PASSWORD='${{ secrets.SPRING_DATASOURCE_PASSWORD }}'
        export EMAIL_VERIFICATION_GOOGLE_ID='${{ secrets.EMAIL_VERIFICATION_GOOGLE_ID }}'
        export EMAIL_VERIFICATION_GOOGLE_PW='${{ secrets.EMAIL_VERIFICATION_GOOGLE_PW }}'
        export EMAIL_VERIFICATION_GOOGLE_ADDRESS='${{ secrets.EMAIL_VERIFICATION_GOOGLE_ADDRESS }}'
        export KAKAO_APP_REST_KEY='${{ secrets.KAKAO_APP_REST_KEY }}'
        export JWT_SECRET='${{ secrets.JWT_SECRET }}'

        nohup java -Dspring.profiles.active=prod \
          -jar /home/ec2-user/deploys/taxi-carpool-0.0.1-SNAPSHOT.jar \
          > /home/ec2-user/logs/log.txt 2>&1 &
        EOF
```

- 또한, 디버깅을 용이하게 하기 위하여 `set -eux` 구문을 추가하였음.