### PR TITLE
[#67] refactor: 로그아웃 로직 변경

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthController.java
@@ -90,7 +90,7 @@ public class AuthController {
         )
         @RequestBody LogoutDTO.LogoutRequestDTO logoutRequest
     ) {
-        authService.logout(logoutRequest.getEmail());
+        authService.logout(logoutRequest.getRefreshToken());
         return ResponseEntity.ok("로그아웃 완료");
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AuthService {
@@ -102,12 +103,11 @@ public class AuthService {
     }
 
     // 로그아웃
-    public void logout(String email) {
-        // 1) 이메일로 Member 조회
-        MemberEntity member = memberService.getMemberEntityByEmail(email);
+    @Transactional
+    public void logout(String refreshToken) {
 
-        // 2) 리프레쉬 토큰 엔티티 조회
-        Optional<RefreshTokenEntity> optionalToken = refreshTokenRepository.findByMember(member);
+        // 리프레쉬 토큰 엔티티 조회
+        Optional<RefreshTokenEntity> optionalToken = refreshTokenRepository.findByRefreshToken(refreshToken);
         if (optionalToken.isPresent()) {
             RefreshTokenEntity tokenEntity = optionalToken.get();
 
@@ -115,7 +115,7 @@ public class AuthService {
             tokenEntity.setExpiryDate(LocalDateTime.now());
             refreshTokenRepository.save(tokenEntity);
         } else {
-            // 토큰없는 로그아웃
+            //
             throw new TokenInvalidException("재로그인 후 로그아웃 해주세요.");
         }
     }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LogoutDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/LogoutDTO.java
@@ -7,23 +7,23 @@ public class LogoutDTO {
 
     public static class LogoutRequestDTO {
 
-        @NotBlank(message = "이메일 공백 오류")
-        @Email(message = "이메일 형식을 지켜주세요.")
-        private String email;
+        @NotBlank(message = "재로그인 후 로그아웃 해주세요.") // 토큰 없는 로그아웃 요청
+        private String refreshToken;
 
         public LogoutRequestDTO() {
         }
 
-        public LogoutRequestDTO(String email) {
-            this.email = email;
+        public LogoutRequestDTO(String refreshToken) {
+            this.refreshToken = refreshToken;
         }
 
-        public String getEmail() {
-            return email;
+        public @NotBlank(message = "재로그인 후 로그아웃 해주세요.") String getRefreshToken() {
+            return refreshToken;
         }
 
-        public void setEmail(String email) {
-            this.email = email;
+        public void setRefreshToken(
+            @NotBlank(message = "재로그인 후 로그아웃 해주세요.") String refreshToken) {
+            this.refreshToken = refreshToken;
         }
     }
 


### PR DESCRIPTION
- 기존: email을 받아서 조회 후, 토큰 무효화
- 변경: refreshToken으로 바로 토큰 무효화