### PR TITLE
[#100] 채팅방 공지사항 관련 기능 구현

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingController.java
@@ -1,12 +1,16 @@
 package edu.kangwon.university.taxicarpool.chatting;
 
 import edu.kangwon.university.taxicarpool.chatting.dto.MessageResponseDTO;
+import edu.kangwon.university.taxicarpool.chatting.dto.NotificationRequestDTO;
+import edu.kangwon.university.taxicarpool.chatting.dto.NotificationResponseDTO;
 import edu.kangwon.university.taxicarpool.chatting.dto.ParticipantResponseDTO;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,6 +45,20 @@ public class ChattingController {
             .getPrincipal();
         List<ParticipantResponseDTO> list = chattingService.getParticipants(partyId, memberId);
         return ResponseEntity.ok(list);
+    }
+
+    @PutMapping("/notification")
+    public ResponseEntity<NotificationResponseDTO> updateNotification(
+        @PathVariable Long partyId,
+        @RequestBody NotificationRequestDTO request
+    ) {
+        Long memberId = (Long) SecurityContextHolder.getContext()
+            .getAuthentication().getPrincipal();
+
+        NotificationResponseDTO response = chattingService
+            .updateNotification(partyId, memberId, request.getNotification());
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingController.java
@@ -37,7 +37,9 @@ public class ChattingController {
     @GetMapping("/participants")
     public ResponseEntity<List<ParticipantResponseDTO>> getParticipants(
         @PathVariable Long partyId) {
-        List<ParticipantResponseDTO> list = chattingService.getParticipants(partyId);
+        Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication()
+            .getPrincipal();
+        List<ParticipantResponseDTO> list = chattingService.getParticipants(partyId, memberId);
         return ResponseEntity.ok(list);
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/dto/NotificationRequestDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/dto/NotificationRequestDTO.java
@@ -1,0 +1,18 @@
+package edu.kangwon.university.taxicarpool.chatting.dto;
+
+public class NotificationRequestDTO {
+
+    private String notification;
+
+    public NotificationRequestDTO() {
+    }
+
+    public String getNotification() {
+        return notification;
+    }
+
+    public void setNotification(String notification) {
+        this.notification = notification;
+    }
+
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/dto/NotificationResponseDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/dto/NotificationResponseDTO.java
@@ -1,0 +1,21 @@
+package edu.kangwon.university.taxicarpool.chatting.dto;
+
+public class NotificationResponseDTO {
+
+    private Long partyId;
+    private String notification;
+
+    public NotificationResponseDTO(Long partyId, String notification) {
+        this.partyId = partyId;
+        this.notification = notification;
+    }
+
+    public Long getPartyId() {
+        return partyId;
+    }
+
+    public String getNotification() {
+        return notification;
+    }
+
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
@@ -170,6 +170,9 @@ public class PartyEntity {
     })
     private MapPlace endPlace;
 
+    @Column(name = "notification")
+    private String notification;
+
     public String getName() {
         return name;
     }
@@ -300,6 +303,14 @@ public class PartyEntity {
 
     public void setEndPlace(MapPlace endPlace) {
         this.endPlace = endPlace;
+    }
+
+    public String getNotification() {
+        return notification;
+    }
+
+    public void setNotification(String notification) {
+        this.notification = notification;
     }
 
     public PartyEntity updateParty(

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -33,7 +33,6 @@ public class PartyService {
 
     private final PartyRepository partyRepository;
     private final PartyMapper partyMapper;
-    // 추후에 merge되면 memberService로 바꿔서 해도 괜찮을듯
     private final MemberRepository memberRepository;
     private final ChattingService chattingService;
 


### PR DESCRIPTION
- 방장이 채팅방에 공지사항을 올릴 수 있는 기능(엔드포인트) 구현
- 또한 메시지 전송, 참여자 목록 API에 요청 멤버가 해당 파티의 파티원인지 검증하는 로직 추가