### PR TITLE
채팅 flow 변경

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChatWebSocketController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChatWebSocketController.java
@@ -6,11 +6,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 
 @Tag(name = "ChatWebSocket", description = "WebSocket STOMP 채팅 메시지 발행 API")
@@ -30,26 +30,19 @@ public class ChatWebSocketController {
     /**
      * 클라이언트→서버 메시지 발행을 처리하고, 브로커로 브로드캐스트까지 수행. destination: /pub/party/{partyId}/message
      */
-    @Operation(
-        summary = "채팅 메시지 전송",
-        description = "클라이언트→서버 STOMP 메시지 발행 후 브로커로 브로드캐스트합니다."
-    )
+    @Operation(summary = "채팅 메시지 전송", description = "클라이언트→서버 STOMP 메시지 발행 후 브로커로 브로드캐스트합니다.")
     @MessageMapping("/party/{partyId}/message")
-    public void sendMessage(@Parameter(
-        description = "메시지를 발행할 파티 ID", required = true)
-    @DestinationVariable Long partyId,
-        @Payload MessageCreateDTO dto
-    ) {
-        Long memberId = (Long) SecurityContextHolder.getContext()
-            .getAuthentication().getPrincipal();
+    public void sendMessage(@Parameter(description = "메시지를 발행할 파티 ID", required = true)
+        @DestinationVariable Long partyId,
+        @Payload MessageCreateDTO dto,
+        Principal principal) {
+
+        Long memberId = Long.valueOf(principal.getName());
         // 서비스에서 메시지 저장 + DTO 변환
         MessageResponseDTO response =
             chattingService.sendMessage(partyId, memberId, dto.getContent());
 
         // 브로커로 브로드캐스트 (SUBSCRIBE prefix: /sub)
-        messagingTemplate.convertAndSend(
-            "/sub/party/" + partyId,
-            response
-        );
+        messagingTemplate.convertAndSend("/sub/party/" + partyId, response);
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/dto/MessageCreateDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/dto/MessageCreateDTO.java
@@ -7,6 +7,9 @@ public class MessageCreateDTO {
 
     private String content;
 
+    public MessageCreateDTO() {
+    }
+
     public MessageCreateDTO(String content) {
         this.content = content;
     }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/WebSocketConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/WebSocketConfig.java
@@ -13,6 +13,7 @@ import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -78,7 +79,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             public Message<?> preSend(Message<?> message, MessageChannel channel) {
                 StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
                 if (accessor.getUser() == null) {
-                    throw new IllegalArgumentException("인증 정보 없음");
+                    throw new AccessDeniedException("인증 정보 없음");
                 }
                 return message;
             }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/WebSocketConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/WebSocketConfig.java
@@ -1,26 +1,33 @@
 package edu.kangwon.university.taxicarpool.config;
 
 import edu.kangwon.university.taxicarpool.chatting.JwtHandshakeInterceptor;
-import edu.kangwon.university.taxicarpool.chatting.JwtStompInterceptor;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker // STOMP 메시지 브로커 활성화
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    private final JwtStompInterceptor jwtStompInterceptor;
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
 
     @Autowired
-    public WebSocketConfig(JwtStompInterceptor jwtStompInterceptor,
-        JwtHandshakeInterceptor jwtHandshakeInterceptor) {
-        this.jwtStompInterceptor = jwtStompInterceptor;
+    public WebSocketConfig(JwtHandshakeInterceptor jwtHandshakeInterceptor) {
         this.jwtHandshakeInterceptor = jwtHandshakeInterceptor;
     }
 
@@ -39,15 +46,43 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // WebSocket 엔드포인트 설정(이렇게만 해줘도 통신 터널을 열어두는 로직 반영됨)
         registry.addEndpoint("/chat")
-            .addInterceptors(jwtHandshakeInterceptor)
+            .addInterceptors(
+                jwtHandshakeInterceptor) // http요청(웹소켓연결요청)에서 쿼리파라미터 내의 JWT토큰을 웹소켓 attribute에 저장 및 JWT토큰 검증
+            .setHandshakeHandler(
+                new DefaultHandshakeHandler() { // Principal을 반환하는 메서드. 웹소켓 세션에 해당 메서드 결과가 저장됨.
+                    @Override
+                    protected Principal determineUser(
+                        ServerHttpRequest request,
+                        WebSocketHandler wsHandler,
+                        Map<String, Object> attributes
+                        // jwtHandshakeInterceptor의 파라미터로 주어지는 attribute와 동일한 객체. 값이 공유됨.
+                    ) {
+                        // HandshakeInterceptor 에서 넣어둔 userId 꺼내서 Principal 반환
+                        Long userId = (Long) attributes.get("userId");
+                        // jwtHandshakeInterceptor에서 null 체크를 했으므로 바로 리턴
+                        return new UsernamePasswordAuthenticationToken(
+                            userId.toString(),    // name 으로 들어감 → principal.getName()
+                            null,
+                            Collections.emptyList()
+                        );
+                    }
+                })
             .setAllowedOriginPatterns("*")
             .withSockJS();
     }
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        // STOMP CONNECT 프레임을 가로채서 JWT 검증
-        registration.interceptors(jwtStompInterceptor);
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+                if (accessor.getUser() == null) {
+                    throw new IllegalArgumentException("인증 정보 없음");
+                }
+                return message;
+            }
+        });
     }
 
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundExce
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import java.nio.file.AccessDeniedException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -275,6 +276,17 @@ public class GlobalExceptionHandler {
             request.getRequestURI()
         );
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponseDTO> handleAccessDeniedException(
+        AccessDeniedException ex, HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.FORBIDDEN.value(),
+            ex.getMessage(),
+            request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -22,12 +22,12 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundExce
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
-import java.nio.file.AccessDeniedException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;


### PR DESCRIPTION
- 기존 STOMP 프로토콜에서 메세지를 주고받을 때 헤더에 토큰을 포함하고 이를 검증하였음.
- 하지만 프론트에서 SockJS()를 통해 소켓 연결을 시도할 경우 헤더에 토큰을 담지 못한다고 함.
- 따라서 JWT토큰을 소켓 연결 시도 시 쿼리스트링으로 넘겨받아 세션 attribute에 저장하도록 하였음.
- 또한 attribute에 있는 정보를 Principal로 저장하도록 하였음.
- 최종적으로 핸드셰이킹 과정에서 토큰을 한 번 검사하고 멤버 정보를 세션에 저장하여 ENTER, SEND, SUBSCRIBE 등의 STOMP 프로토콜 호출 시 토큰에 대한 검증은 하지 않도록 변경하였음.
- 토큰을 최초 한 번만 검증하며 쿼리스트링에 토큰을 노출시키지만 서버와 https 및 wss로 통신하기 때문에 보안상 문제는 발생하지 않을 것으로 예상됨.

혹시 변경사항에 대해 이유가 궁금하거나 이해가 되지 않는 부분 있으면 알려주세요!