### PR TITLE
feat: 과거 메세지 조회 API 개선

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingController.java
@@ -36,18 +36,21 @@ public class ChattingController {
         description = "특정 파티의 과거 메세지 기록을 가져옵니다.\n"
             + "afterMessageId=3 이면 4부터 오름차순으로 조회 되며, "
             + "afterMessageId를 포함하지 않는 경우 전체 메세지가 오름차순으로 조회됩니다."
+            + "maxResults는 가져올 메세지의 최대 개수입니다. 기본값은 20입니다."
     )
     @GetMapping("/messages")
     public ResponseEntity<List<MessageResponseDTO>> getMessageHistory(
         @Parameter(description = "조회할 파티 ID") @PathVariable Long partyId,
         @Parameter(description = "기준이 되는 메세지 ID")
-        @RequestParam(required = false) Long afterMessageId) {
+        @RequestParam(required = false) Long afterMessageId,
+        @Parameter(description = "최대 메시지 개수")
+        @RequestParam(required = false, defaultValue = "20") int maxResults) {
         // JWT 토큰에서 사용자 ID 추출
         Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication()
             .getPrincipal();
 
         List<MessageResponseDTO> messages = chattingService.getMessageHistory(partyId, memberId,
-            afterMessageId);
+            afterMessageId, maxResults);
 
         return ResponseEntity.ok(messages);
     }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/MessageRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/MessageRepository.java
@@ -1,6 +1,7 @@
 package edu.kangwon.university.taxicarpool.chatting;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,12 +13,13 @@ public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
         "WHERE m.party.id = :partyId AND m.id > :id " +
         "ORDER BY m.id ASC")
     List<MessageEntity> findByPartyIdAndIdGreaterThanOrderByIdAsc(@Param("partyId") Long partyId,
-        @Param("id") Long id);
+        @Param("id") Long id, Pageable pageable);
 
     @Query("SELECT m FROM MessageEntity m " +
         "LEFT JOIN FETCH m.sender " +
         "WHERE m.party.id = :partyId " +
         "ORDER BY m.id ASC")
-    List<MessageEntity> findByPartyIdOrderByIdAsc(@Param("partyId") Long partyId);
+    List<MessageEntity> findByPartyIdOrderByIdAsc(@Param("partyId") Long partyId,
+        Pageable pageable);
 
 }


### PR DESCRIPTION
- 기존 메세지 조회 API의 경우 afterMessageId를 파라미터로 명시하지 않는 경우 전체 메세지를 가져왔음.

- 이를 maxResult 파라미터를 사용해 최대 메세지 개수를 제한할 수 있도록 변경하였음.