### PR TITLE
feat: 지도 검색 API에서 위도 경도 삭제

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/map/MapController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/map/MapController.java
@@ -28,11 +28,9 @@ public class MapController {
     )
     @GetMapping("/search")
     public ResponseEntity<MapSearchResponseDTO> searchPlaces(
-        @Parameter(description = "검색 키워드", required = true) @RequestParam String keyword,
-        @Parameter(description = "경도 (longitude)", example = "127.0") @RequestParam double x, // 경도
-        @Parameter(description = "위도 (latitude)", example = "37.0") @RequestParam double y  // 위도
+        @Parameter(description = "검색 키워드", required = true) @RequestParam String keyword
     ) {
-        MapSearchResponseDTO result = mapService.search(keyword, x, y);
+        MapSearchResponseDTO result = mapService.search(keyword);
         return ResponseEntity.ok(result);
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/map/MapService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/map/MapService.java
@@ -22,17 +22,19 @@ public class MapService {
 
     @Value("${kakao.api.key}")
     private String kakaoApiKey;
+    private final double LATITUDE_KNU = 37.869129;
+    private final double LONGITUDE_KNU = 127.742718;
 
     public MapService(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
-    public MapSearchResponseDTO search(String keyword, double x, double y) {
+    public MapSearchResponseDTO search(String keyword) {
         String url = UriComponentsBuilder.fromUriString(
                 "https://dapi.kakao.com/v2/local/search/keyword.json")
             .queryParam("query", keyword)
-            .queryParam("x", x)
-            .queryParam("y", y)
+            .queryParam("x", LATITUDE_KNU)
+            .queryParam("y", LONGITUDE_KNU)
             .queryParam("radius", 2000) // 일단 반경 2km로 고정
             .queryParam("page", 1)
             .queryParam("size", 15)


### PR DESCRIPTION
- 기존 지도 검색 API는 위도와 경도를 입력받아 해당 위치와 가까운 장소를 반환하였음.
- 하지만 이는 타 지역에서 검색시 학교 근처의 장소가 검색되지 않는 문제가 존재함.
- 따라서 위도와 경도를 학교 근처로 고정하였음.