### PR TITLE
[#161] feat: 비밀번호 찾기(변경) 기능 구현

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthController.java
@@ -1,5 +1,7 @@
 package edu.kangwon.university.taxicarpool.auth;
 
+import edu.kangwon.university.taxicarpool.auth.dto.LoginDTO;
+import edu.kangwon.university.taxicarpool.auth.dto.LogoutDTO;
 import edu.kangwon.university.taxicarpool.member.dto.MemberCreateDTO;
 import edu.kangwon.university.taxicarpool.member.dto.MemberDetailDTO;
 import io.swagger.v3.oas.annotations.Operation;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/AuthService.java
@@ -3,6 +3,7 @@ package edu.kangwon.university.taxicarpool.auth;
 import edu.kangwon.university.taxicarpool.auth.authException.AuthenticationFailedException;
 import edu.kangwon.university.taxicarpool.auth.authException.TokenExpiredException;
 import edu.kangwon.university.taxicarpool.auth.authException.TokenInvalidException;
+import edu.kangwon.university.taxicarpool.auth.dto.LoginDTO;
 import edu.kangwon.university.taxicarpool.email.EmailVerificationService;
 import edu.kangwon.university.taxicarpool.email.exception.EmailVerificationNotFoundException;
 import edu.kangwon.university.taxicarpool.member.MemberEntity;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/dto/LoginDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/dto/LoginDTO.java
@@ -1,4 +1,4 @@
-package edu.kangwon.university.taxicarpool.auth;
+package edu.kangwon.university.taxicarpool.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/dto/LogoutDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/dto/LogoutDTO.java
@@ -1,6 +1,5 @@
-package edu.kangwon.university.taxicarpool.auth;
+package edu.kangwon.university.taxicarpool.auth.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public class LogoutDTO {

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetController.java
@@ -1,0 +1,33 @@
+package edu.kangwon.university.taxicarpool.auth.reset;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Password Reset", description = "비밀번호 재설정(링크 발송/1회용 토큰 사용) API")
+@RestController
+@RequestMapping("/api/password")
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    public PasswordResetController(PasswordResetService passwordResetService) {
+        this.passwordResetService = passwordResetService;
+    }
+
+    @Operation(summary = "비밀번호 재설정 링크 발송", description = "입력한 이메일로 1회용 토큰이 포함된 링크를 보냅니다.")
+    @PostMapping("/reset-link")
+    public ResponseEntity<String> sendLink(@Valid @RequestBody PasswordResetDTO.SendLinkRequest request) {
+        passwordResetService.sendResetLink(request.getEmail());
+        return ResponseEntity.ok("비밀번호 재설정 안내 메일을 발송했습니다. 10분안에 변경해주세요.");
+    }
+
+    @Operation(summary = "비밀번호 재설정", description = "이메일 링크의 토큰으로 새 비밀번호로 변경합니다.")
+    @PatchMapping("/reset")
+    public ResponseEntity<String> reset(@Valid @RequestBody PasswordResetDTO.ResetRequest request) {
+        passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
+        return ResponseEntity.ok("비밀번호가 변경되었습니다.");
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetDTO.java
@@ -1,0 +1,32 @@
+package edu.kangwon.university.taxicarpool.auth.reset;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class PasswordResetDTO {
+
+    public static class SendLinkRequest {
+        @Schema(description = "비번 재설정 링크를 받을 이메일")
+        @NotBlank @Email
+        private String email;
+
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+    }
+
+    public static class ResetRequest {
+        @Schema(description = "이메일 링크에 포함된 1회용 토큰")
+        @NotBlank
+        private String token;
+
+        @Schema(description = "새 비밀번호")
+        @NotBlank
+        private String newPassword;
+
+        public String getToken() { return token; }
+        public void setToken(String token) { this.token = token; }
+        public String getNewPassword() { return newPassword; }
+        public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetService.java
@@ -1,0 +1,141 @@
+package edu.kangwon.university.taxicarpool.auth.reset;
+
+import edu.kangwon.university.taxicarpool.auth.JwtUtil;
+import edu.kangwon.university.taxicarpool.auth.authException.TokenExpiredException;
+import edu.kangwon.university.taxicarpool.auth.authException.TokenInvalidException;
+import edu.kangwon.university.taxicarpool.email.exception.EmailSendFailedException;
+import edu.kangwon.university.taxicarpool.member.MemberEntity;
+import edu.kangwon.university.taxicarpool.member.MemberRepository;
+import edu.kangwon.university.taxicarpool.member.MemberService;
+import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class PasswordResetService {
+
+    private final MemberService memberService;
+    private final PasswordResetTokenRepository tokenRepository;
+    private final JavaMailSender mailSender;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${email.address}")
+    private String emailAddress;
+
+    @Value("${email.name}")
+    private String emailName;
+
+    // 프론트 리셋 페이지 베이스 URL
+    @Value("${app.password-reset.base-url:http://localhost:3000/reset-password}")
+    private String resetBaseUrl;
+
+    // 1회용 토큰 유효시간(분)
+    private static final long RESET_TOKEN_MINUTES = 10;
+
+    public PasswordResetService(MemberService memberService,
+        PasswordResetTokenRepository tokenRepository,
+        JavaMailSender mailSender,
+        JwtUtil jwtUtil,
+        PasswordEncoder passwordEncoder) {
+        this.memberService = memberService;
+        this.tokenRepository = tokenRepository;
+        this.mailSender = mailSender;
+        this.jwtUtil = jwtUtil;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * 비밀번호 재설정 링크 발송 (존재 여부는 항상 동일한 응답으로 은닉)
+     */
+    @Transactional
+    public void sendResetLink(String email) {
+        MemberEntity member = memberService.getMemberEntityByEmail(email);
+        if (member == null) {
+            // 예외처리는 getMemberEntityByEmail에서 구현중
+            return;
+        }
+
+        // jti 생성 및 DB 저장(PasswordResetTokenEntity는 사실 상 jtiEntity)
+        String jti = JwtUtil.newJti();
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(RESET_TOKEN_MINUTES);
+        PasswordResetTokenEntity tokenEntity = new PasswordResetTokenEntity(jti, member, expiresAt);
+        tokenRepository.save(tokenEntity);
+
+        // jti를 넣어서 JWT 생성 (subject=memberId, jti 포함, 짧은 만료)
+        String jwt = jwtUtil.generatePasswordResetToken(
+            member.getId(), jti, 1000L * 60 * RESET_TOKEN_MINUTES
+        );
+
+        // 링크 생성
+        String link = resetBaseUrl + "?token=" + jwt;
+
+        // 메일 발송
+        sendResetEmail(email, link);
+    }
+
+    /**
+     * 토큰 검증 후 비밀번호 변경(1회용)
+     */
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        // 1) 토큰 기본 검증(서명/만료)
+        var claims = jwtUtil.parseClaims(token);
+        Long memberId = Long.valueOf(claims.getSubject());
+        String jti = String.valueOf(claims.get("jti"));
+        if (jti == null || jti.isBlank()) {
+            throw new TokenInvalidException("유효하지 않은 토큰(jti 누락)");
+        }
+
+        // 2) DB에서 jti 조회 → 1회성/만료 검증 + 토큰 대상 일치 확인
+        PasswordResetTokenEntity tokenEntity = tokenRepository.findByJti(jti)
+            .orElseThrow(() -> new TokenInvalidException("유효하지 않은 토큰(jti 없음)"));
+
+        if (tokenEntity.isUsed()) {
+            throw new TokenInvalidException("이미 사용된 토큰입니다.");
+        }
+        if (tokenEntity.isExpired()) {
+            throw new TokenExpiredException("토큰이 만료되었습니다. 다시 요청해 주세요.");
+        }
+        if (!tokenEntity.getMember().getId().equals(memberId)) {
+            throw new TokenInvalidException("토큰 대상 정보가 일치하지 않습니다.");
+        }
+
+        // 3) 비밀번호 변경
+        MemberEntity member = tokenEntity.getMember();
+        member.setPassword(passwordEncoder.encode(newPassword));
+
+        // 4) 토큰 사용 처리(1회용)
+        tokenEntity.markUsed();
+
+        // JPA flush는 @Transactional 종료 시점에 자동으로 반영되어서 save 불필요
+    }
+
+    private void sendResetEmail(String to, String resetLink) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
+            helper.setFrom(new InternetAddress(emailAddress, emailName));
+            helper.setTo(to);
+            helper.setSubject("[강원대 택시카풀] 비밀번호 재설정 안내");
+            helper.setText(
+                "아래 링크를 통해 비밀번호를 재설정하세요.\n\n" + resetLink +
+                    "\n\n링크 유효시간: " + RESET_TOKEN_MINUTES + "분",
+                false
+            );
+            mailSender.send(message);
+        } catch (Exception e) {
+            // 발송 실패 시에도 계정 존재 여부 노출을 피하기 위해 외부 응답은 동일하게 처리하지만,
+            // 서버 로그/모니터링으로는 원인 파악 가능해야 함.
+            throw new EmailSendFailedException("비밀번호 재설정 메일 전송 실패");
+        }
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetTokenEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetTokenEntity.java
@@ -1,0 +1,59 @@
+package edu.kangwon.university.taxicarpool.auth.reset;
+
+import edu.kangwon.university.taxicarpool.member.MemberEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "password_reset_token", indexes = {
+    @Index(name = "idx_password_reset_token_jti", columnList = "jti", unique = true)
+})
+public class PasswordResetTokenEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String jti; // JWT ID(고유 식별자)
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private MemberEntity member;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean used;  // 1회용 사용 여부
+
+    private LocalDateTime usedAt;
+
+    protected PasswordResetTokenEntity() {}
+
+    public PasswordResetTokenEntity(String jti, MemberEntity member, LocalDateTime expiresAt) {
+        this.jti = jti;
+        this.member = member;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+        this.used = false;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void markUsed() {
+        this.used = true;
+        this.usedAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public String getJti() { return jti; }
+    public MemberEntity getMember() { return member; }
+    public LocalDateTime getExpiresAt() { return expiresAt; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public boolean isUsed() { return used; }
+    public LocalDateTime getUsedAt() { return usedAt; }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetTokenRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetTokenRepository.java
@@ -1,0 +1,9 @@
+package edu.kangwon.university.taxicarpool.auth.reset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetTokenEntity, Long> {
+    Optional<PasswordResetTokenEntity> findByJti(String jti);
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/SecurityConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                     "/chat/**",                 // websocket
                     "/api/auth/**",             // 회원가입, 로그인
                     "/api/email/**",            // 이메일 인증
+                    "/api/password/reset-link",
+                    "/api/password/reset",
                     "/swagger-ui.html",
                     "/swagger-ui/**",           // 스웨거 UI리소스
                     "/api-docs/**",          // 스웨거 API 문서
@@ -63,8 +65,7 @@ public class SecurityConfig {
                     "/api/map/search"
                 ).permitAll()
                 // 그 외 모든 요청은 인증 필요
-                //.anyRequest().authenticated()
-                .anyRequest().permitAll()
+                .anyRequest().authenticated()
             )
             // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
             // 난 수동으로 회원가입 DB접근으로 검증해서 UsernamePasswordAuthenticationFilter 안 쓰이긴 함.

--- a/taxi-carpool/src/main/resources/application-prod.properties
+++ b/taxi-carpool/src/main/resources/application-prod.properties
@@ -33,3 +33,6 @@ springdoc.swagger-ui.path=/swagger-ui.html
 
 # src/main/resources/application.properties
 logging.level.edu.kangwon.university.taxicarpool.chatting=DEBUG
+
+# password reset
+app.password-reset.base-url=${APP_PASSWORD_RESET_BASE_URL}

--- a/taxi-carpool/src/main/resources/application.properties
+++ b/taxi-carpool/src/main/resources/application.properties
@@ -33,3 +33,6 @@ jwt.secret=${JWT_SECRET}
 # swagger
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# password reset
+app.password-reset.base-url=${APP_PASSWORD_RESET_BASE_URL}


### PR DESCRIPTION
### 비밀번호를 잃어버린 상황

- 사용자가 이메일을 입력하고 "비밀번호 찾기" 버튼을 누른다.
- 서버는 해당 이메일이 존재한다면 1회용 비밀번호 재설정 토큰(JWT, jti 포함)을 생성하고 DB에 저장한다.
- 토큰이 포함된 비밀번호 재설정 링크를 이메일로 발송한다.
- 사용자는 이메일 링크를 클릭 → 프론트엔드에서 새로운 비밀번호를 입력할 수 있는 화면으로 이동한다.
- 사용자가 새 비밀번호를 입력하면, 토큰과 함께 서버에 PATCH 요청을 보낸다.
- 서버는 토큰을 검증한다. (서명 확인, 만료시간 확인, jti 중복 사용 여부 확인)
- 검증이 통과되면 해당 사용자의 비밀번호를 새 값으로 업데이트하고 jti를 "사용됨" 상태로 마킹한다.
- 응답으로 "비밀번호 변경 완료" 메시지를 반환한다.
- 만약 토큰이 만료되었거나 이미 사용된 jti라면 "토큰 만료/재요청 필요" 응답을 보낸다.