### PR TITLE
[#165] feat: 택시비 절감 API 구현

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberEntity.java
@@ -53,6 +53,9 @@ public class MemberEntity {
     @OneToMany(mappedBy = "sender")
     private List<MessageEntity> sentMessages = new ArrayList<>();
 
+    @Column(name = "total_saved_amount", nullable = false)
+    private long totalSavedAmount = 0L;
+
     public Long getId() {
         return id;
     }
@@ -104,4 +107,21 @@ public class MemberEntity {
     public void setParties(List<PartyEntity> parties) {
         this.parties = parties;
     }
+
+    public long getTotalSavedAmount() {
+        return totalSavedAmount;
+    }
+
+    public void setTotalSavedAmount(long totalSavedAmount) {
+        this.totalSavedAmount = totalSavedAmount;
+    }
+
+    /** 절감 금액을 누적하는 편의 메서드 */
+    public void addToTotalSavedAmount(long amountToAdd) {
+        if (amountToAdd < 0) {
+            throw new IllegalArgumentException("누적 절감 금액은 음수가 될 수 없습니다.");
+        }
+        this.totalSavedAmount += amountToAdd;
+    }
+
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberService.java
@@ -60,7 +60,8 @@ public class MemberService {
             saved.getId(),
             saved.getEmail(),
             saved.getNickname(),
-            saved.getGender()
+            saved.getGender(),
+            saved.getTotalSavedAmount()
         );
 
         return responseDTO;
@@ -98,7 +99,8 @@ public class MemberService {
             updated.getId(),
             updated.getEmail(),
             updated.getNickname(),
-            updated.getGender()
+            updated.getGender(),
+            updated.getTotalSavedAmount()
         );
     }
 
@@ -115,7 +117,8 @@ public class MemberService {
             entity.getId(),
             entity.getEmail(),
             entity.getNickname(),
-            entity.getGender()
+            entity.getGender(),
+            entity.getTotalSavedAmount()
         );
 
         return responseDTO;
@@ -144,7 +147,8 @@ public class MemberService {
             entity.getId(),
             entity.getEmail(),
             entity.getNickname(),
-            entity.getGender()
+            entity.getGender(),
+            entity.getTotalSavedAmount()
         );
 
         return responseDTO;

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/dto/MemberDetailDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/dto/MemberDetailDTO.java
@@ -4,17 +4,19 @@ import edu.kangwon.university.taxicarpool.member.Gender;
 
 public class MemberDetailDTO {
 
-    public MemberDetailDTO(Long id, String email, String nickname, Gender gender) {
+    public MemberDetailDTO(Long id, String email, String nickname, Gender gender, long totalSavedAmount) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.gender = gender;
+        this.totalSavedAmount = totalSavedAmount;
     }
 
     private Long id;
     private String email;
     private String nickname;
     private Gender gender;
+    private long totalSavedAmount;
 
     public Long getId() {
         return id;
@@ -46,5 +48,13 @@ public class MemberDetailDTO {
 
     public void setGender(Gender gender) {
         this.gender = gender;
+    }
+
+    public long getTotalSavedAmount() {
+        return totalSavedAmount;
+    }
+
+    public void setTotalSavedAmount(long totalSavedAmount) {
+        this.totalSavedAmount = totalSavedAmount;
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyController.java
@@ -146,4 +146,18 @@ public class PartyController {
         return ResponseEntity.ok(myParties);
     }
 
+    @Operation(
+        summary = "파티 절감 금액 계산",
+        description = "호스트가 완료된 파티에 대해 절감 금액을 계산하고, 각 멤버의 누적 절감액(totalSavedAmount)에 반영합니다."
+    )
+    @PostMapping("/{partyId}/savings")
+    public ResponseEntity<Map<String, Object>> calculateSavings(
+        @Parameter(description = "파티 ID", required = true) @PathVariable Long partyId
+    ) {
+        Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Map<String, Object> result = partyService.calculateSavings(partyId, memberId);
+        return ResponseEntity.ok(result);
+    }
+
+
 }

--- a/taxi-carpool/src/main/resources/application-prod.properties
+++ b/taxi-carpool/src/main/resources/application-prod.properties
@@ -36,3 +36,6 @@ logging.level.edu.kangwon.university.taxicarpool.chatting=DEBUG
 
 # password reset
 app.password-reset.base-url=${APP_PASSWORD_RESET_BASE_URL}
+
+# kakaoMobility API
+kakaomobility.api.key=${KAKAOMOBILITY_API_KEY}

--- a/taxi-carpool/src/main/resources/application.properties
+++ b/taxi-carpool/src/main/resources/application.properties
@@ -36,3 +36,6 @@ springdoc.swagger-ui.path=/swagger-ui.html
 
 # password reset
 app.password-reset.base-url=${APP_PASSWORD_RESET_BASE_URL}
+
+# kakaoMobility API
+kakaomobility.api.key=${KAKAOMOBILITY_API_KEY}


### PR DESCRIPTION
- 얼마를 아꼈는지 예측 확률을 높이려면, 실제로 파티방 모임이 진행 되었는지를 파악해야한다.
- 가장 정확한 것은 결제 시스템을 확인하면 될텐데 앱에 결제 시스템이 없다.
- 그래서 대안은 사용자에게 확인받는 것이다.
- 프론트엔드 팀은 파티방에 팀장만 누를 수 있는 버튼을 하나 만든다. 하지만 파티의 약속 시간보다 이후에 보이게 만들어야한다(프론트쪽에서 시간에 따라 UI를 보이게 설정하면 될 듯) 이름은 예를들어 “완료된 파티 체크”정도면 좋을 것 같다.
- 프론트쪽에서 해당 체크 버튼을 누름에 따라 “얼마를 아꼈습니다 API”요청을 보내도록 하자.
- 백엔드에서는 우선 멤버entity에 얼마를 아꼈는지 누적된 값을 담아두는 변수를 선언한다.
    - 백엔드에서는 해당 요청을 받고, 해당 택시 요금 계산 알고리즘에 의하여 얼마를 아꼈는지 계산한다. 이후에 해당 파티방의 참여 인원만큼 그 값을 나눈다. 전체 택시비에서 앞서 나눈 값을 뺀다. 이 값을 얼마를 아꼈는지 나타내주는 변수에 더해서 저장해줘야한다. 해당 파티방의 멤버들도 함께 꺼내서 이 값을 더해준 뒤 저장해줘야한다. 이후에 이 값들을 포함하여 응답을 구성하면 된다.
    - 택시 요금 계산 알고리즘은 카카오 모빌리티 API에서 가져온다.
    - 카카오 모빌리티 API
    - 완료된 파티 체크 버튼을 팀장에게만 보이게 하는 이유 → 카카오 API 호출 하루 5000번 제한이라 아낄 수 있음.