### PR TITLE
[#169] refactor: 택시비 절감 계산 API 리팩토링

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import edu.kangwon.university.taxicarpool.member.exception.DuplicatedEmailExcept
 import edu.kangwon.university.taxicarpool.member.exception.DuplicatedNicknameException;
 import edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.DuplicatedPartyNameException;
+import edu.kangwon.university.taxicarpool.party.partyException.KakaoApiException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberAlreadyInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyAlreadyDeletedException;
@@ -20,6 +21,7 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyFullExceptio
 import edu.kangwon.university.taxicarpool.party.partyException.PartyGetCustomException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyInvalidMaxParticipantException;
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
+import edu.kangwon.university.taxicarpool.party.partyException.SavingsAlreadyCalculatedException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -281,6 +283,28 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PartyInvalidMaxParticipantException.class)
     public ResponseEntity<ErrorResponseDTO> handlePartyInvalidMaxParticipantException(
         PartyInvalidMaxParticipantException ex, HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.BAD_REQUEST.value(),
+            ex.getMessage(),
+            request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(KakaoApiException.class)
+    public ResponseEntity<ErrorResponseDTO> handleKakaoApiException(
+        KakaoApiException ex, HttpServletRequest request) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            HttpStatus.BAD_REQUEST.value(),
+            ex.getMessage(),
+            request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(SavingsAlreadyCalculatedException.class)
+    public ResponseEntity<ErrorResponseDTO> handleSavingsAlreadyCalculatedException (
+        SavingsAlreadyCalculatedException ex, HttpServletRequest request) {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
             HttpStatus.BAD_REQUEST.value(),
             ex.getMessage(),

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
@@ -172,6 +172,9 @@ public class PartyEntity {
     @Column(name = "notification")
     private String notification;
 
+    @Column(name = "savings_calculated", nullable = false)
+    private boolean savingsCalculated = false;
+
     public String getName() {
         return name;
     }
@@ -312,6 +315,14 @@ public class PartyEntity {
         this.notification = notification;
     }
 
+    public boolean isSavingsCalculated() {
+        return savingsCalculated;
+    }
+
+    public void setSavingsCalculated(boolean savingsCalculated) {
+        this.savingsCalculated = savingsCalculated;
+    }
+
     public PartyEntity updateParty(
         boolean sameGenderOnly,
         boolean costShareBeforeDropOff,
@@ -321,7 +332,8 @@ public class PartyEntity {
         String comment,
         int maxParticipantCount,
         MapPlace startPlace,
-        MapPlace endPlace
+        MapPlace endPlace,
+        String notification
     ) {
         this.sameGenderOnly = sameGenderOnly;
         this.costShareBeforeDropOff = costShareBeforeDropOff;
@@ -332,6 +344,7 @@ public class PartyEntity {
         this.maxParticipantCount = maxParticipantCount;
         this.startPlace = startPlace;
         this.endPlace = endPlace;
+        this.notification = notification;
         return this;
     }
 

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyMapper.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyMapper.java
@@ -50,7 +50,9 @@ public class PartyMapper {
             partyEntity.getCurrentParticipantCount(),
             partyEntity.getMaxParticipantCount(),
             startDto,
-            endDto
+            endDto,
+            partyEntity.getNotification(),
+            partyEntity.isSavingsCalculated()
         );
     }
 
@@ -97,7 +99,8 @@ public class PartyMapper {
             partyUpdateRequestDTO.getComment(),
             partyUpdateRequestDTO.getMaxParticipantCount(),
             startPlace,
-            endPlace
+            endPlace,
+            partyUpdateRequestDTO.getNotification()
         );
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/dto/PartyDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/dto/PartyDTO.java
@@ -44,6 +44,10 @@ public class PartyDTO {
 
         private MapPlaceDTO endPlace;
 
+        private String notification;
+
+        private boolean savingsCalculated;
+
         public PartyResponseDTO(
             Long id,
             String name,
@@ -60,7 +64,9 @@ public class PartyDTO {
             int currentParticipantCount,
             int maxParticipantCount,
             MapPlaceDTO startPlace,
-            MapPlaceDTO endPlace) {
+            MapPlaceDTO endPlace,
+            String notification,
+            boolean savingsCalculated) {
             this.id = id;
             this.name = name;
             this.isDeleted = isDeleted;
@@ -77,6 +83,8 @@ public class PartyDTO {
             this.maxParticipantCount = maxParticipantCount;
             this.startPlace = startPlace;
             this.endPlace = endPlace;
+            this.notification = notification;
+            this.savingsCalculated = savingsCalculated;
         }
 
         public Long getId() {
@@ -205,6 +213,22 @@ public class PartyDTO {
 
         public void setEndPlace(MapPlaceDTO endPlace) {
             this.endPlace = endPlace;
+        }
+
+        public String getNotification() {
+            return notification;
+        }
+
+        public void setNotification(String notification) {
+            this.notification = notification;
+        }
+
+        public boolean isSavingsCalculated() {
+            return savingsCalculated;
+        }
+
+        public void setSavingsCalculated(boolean savingsCalculated) {
+            this.savingsCalculated = savingsCalculated;
         }
     }
 
@@ -364,6 +388,8 @@ public class PartyDTO {
 
         private MapPlaceDTO endPlace;
 
+        private String notification;
+
         public PartyUpdateRequestDTO(
             boolean sameGenderOnly,
             boolean costShareBeforeDropOff,
@@ -373,7 +399,8 @@ public class PartyDTO {
             String comment,
             int maxParticipantCount,
             MapPlaceDTO startPlace,
-            MapPlaceDTO endPlace
+            MapPlaceDTO endPlace,
+            String notification
         ) {
             this.sameGenderOnly = sameGenderOnly;
             this.costShareBeforeDropOff = costShareBeforeDropOff;
@@ -384,6 +411,7 @@ public class PartyDTO {
             this.maxParticipantCount = maxParticipantCount;
             this.startPlace = startPlace;
             this.endPlace = endPlace;
+            this.notification = notification;
         }
 
         public boolean isSameGenderOnly() {
@@ -456,6 +484,14 @@ public class PartyDTO {
 
         public void setEndPlace(MapPlaceDTO endPlace) {
             this.endPlace = endPlace;
+        }
+
+        public String getNotification() {
+            return notification;
+        }
+
+        public void setNotification(String notification) {
+            this.notification = notification;
         }
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/KakaoApiException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/KakaoApiException.java
@@ -1,0 +1,10 @@
+package edu.kangwon.university.taxicarpool.party.partyException;
+
+public class KakaoApiException extends RuntimeException {
+    public KakaoApiException(String message) {
+        super(message);
+    }
+    public KakaoApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/SavingsAlreadyCalculatedException.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/partyException/SavingsAlreadyCalculatedException.java
@@ -1,0 +1,11 @@
+package edu.kangwon.university.taxicarpool.party.partyException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class SavingsAlreadyCalculatedException extends RuntimeException {
+    public SavingsAlreadyCalculatedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
- 기본 예외처리 -> 커스텀 예외처리로 변경
- 응답 1번 이후에 중복으로 들어오지 않도록 방어를 위해 PartyEntity에 관련 필드 추가.
- 위도/경도가 0일 때 카카오 모빌리티 API응답에서 예외 발생으로 500에러 응답 -> 관련 검증 및 예외처리 추가