### PR TITLE
[#184] feat: 엑세스 토큰 무효화 기능

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/JwtAuthenticationFilter.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/JwtAuthenticationFilter.java
@@ -1,12 +1,15 @@
 package edu.kangwon.university.taxicarpool.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.kangwon.university.taxicarpool.auth.authException.TokenExpiredException;
 import edu.kangwon.university.taxicarpool.auth.authException.TokenInvalidException;
+import edu.kangwon.university.taxicarpool.member.MemberRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Map;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -15,9 +18,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
 
-    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, MemberRepository memberRepository) {
         this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
     }
 
     @Override
@@ -36,6 +41,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 if (jwtUtil.validateToken(token)) {
                     // 3) 토큰에서 사용자 식별값(id) 추출
                     Long id = jwtUtil.getIdFromToken(token);
+                    int verInToken = jwtUtil.getTokenVersionFromToken(token);
+
+                    // 3-1) DB의 최신 tokenVersion 조회
+                    int verInDb = memberRepository.findTokenVersionById(id);
+
+                    // 3-2) 버전 불일치면 "다른 기기에서 더 최근에 로그인" → 401
+                    if (verInToken != verInDb) {
+                        writeUnauthorized(response, "AUTH-VERSION-MISMATCH",
+                            "다른 기기에서 더 최근에 로그인되어 현재 토큰이 무효화되었습니다. 다시 로그인해주세요.");
+                        return;
+                    }
 
                     // 4) 인증 객체 생성 (권한이 필요하면 loadUserByUsername() 등을 통해 가져올 수 있음)
                     UsernamePasswordAuthenticationToken authentication =
@@ -48,17 +64,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             } catch (TokenExpiredException e) {
                 // 토큰 만료 시 401 응답 -> 프론트측에서 이거 받고 Axios를 통해 재요청 보내면 댐.
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write("Access Token 만료");
+                writeUnauthorized(response, "AUTH-EXPIRED", "Access 토큰이 만료되었습니다.");
                 return;
             } catch (TokenInvalidException e) {
                 // 토큰이 위조되었거나 형식이 잘못됨
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write("위조 or 형식이 잘못된 토큰");
+                writeUnauthorized(response, "AUTH-INVALID", "유효하지 않은 토큰입니다.");
                 return;
             }
         }
         // 다음 필터로 진행
         filterChain.doFilter(request, response);
     }
+
+    private void writeUnauthorized(HttpServletResponse response, String code, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> body = Map.of(
+            "status", 401,
+            "code", code,
+            "message", message,        // 한글 메시지 OK
+            "timestamp", System.currentTimeMillis()
+        );
+        new ObjectMapper().writeValue(response.getWriter(), body);
+    }
+
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/JwtUtil.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/JwtUtil.java
@@ -28,15 +28,15 @@ public class JwtUtil {
     private String SECRET_KEY;
 
     // 엑세스 토큰 생성 메서드
-    public String generateAccessToken(Long id) {
+    public String generateAccessToken(Long id, int tokenVersion) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + ACCESS_EXPIRATION);
 
-        // 헤더랑 페이로드, 사용자 정보(id)로 시그니처 만듦.
         return Jwts.builder()
-            .setSubject(String.valueOf(id))         // 토큰 식별자 (id 등)
-            .setIssuedAt(now)          // 발급 시간
-            .setExpiration(expiryDate) // 만료 시간
+            .setSubject(String.valueOf(id))
+            .setIssuedAt(now)
+            .setExpiration(expiryDate)
+            .claim("ver", tokenVersion)
             .signWith(getSigningKey(), SignatureAlgorithm.HS256)
             .compact();
     }
@@ -68,6 +68,15 @@ public class JwtUtil {
             .getBody()
             .getSubject();
         return Long.parseLong(subject);
+    }
+
+    public int getTokenVersionFromToken(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(getSigningKey())
+            .build()
+            .parseClaimsJws(token)
+            .getBody()
+            .get("ver", Integer.class);
     }
 
     // 토큰 검증

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/JwtHandshakeInterceptor.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/JwtHandshakeInterceptor.java
@@ -1,10 +1,14 @@
 package edu.kangwon.university.taxicarpool.chatting;
 
 import edu.kangwon.university.taxicarpool.auth.JwtUtil;
+import edu.kangwon.university.taxicarpool.member.MemberRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
@@ -17,9 +21,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
     private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
 
-    public JwtHandshakeInterceptor(JwtUtil jwtUtil) {
+    public JwtHandshakeInterceptor(JwtUtil jwtUtil, MemberRepository memberRepository) { // ★ 변경
         this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
     }
 
     @Override
@@ -29,12 +35,23 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
         Map<String, Object> attributes) {
         String token = extractToken(request);
         if (token == null) {
-            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            writeUnauthorized(response, "WS-NO-TOKEN", "access_token이 없습니다.");
             return false;
         }
 
         jwtUtil.validateToken(token);
+
         Long userId = jwtUtil.getIdFromToken(token);
+        int verInToken = jwtUtil.getTokenVersionFromToken(token);
+
+        int verInDb = memberRepository.findTokenVersionById(userId);
+
+        if (verInToken != verInDb) {
+            writeUnauthorized(response, "WS-VERSION-MISMATCH",
+                "다른 기기에서 더 최근에 로그인되어 현재 토큰이 무효화되었습니다. 다시 로그인해주세요.");
+            return false;
+        }
+
         // STOMP의 모든 단계에서 범용적으로 사용할 수 있도록 Principal로 저장
         UsernamePasswordAuthenticationToken principal =
             new UsernamePasswordAuthenticationToken(userId, null, null);
@@ -58,5 +75,20 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
             return tokens.get(0);
         }
         return null;
+    }
+
+    private void writeUnauthorized(ServerHttpResponse response, String code, String message) {
+        try {
+            if (response instanceof ServletServerHttpResponse s) {
+                HttpServletResponse r = s.getServletResponse();
+                r.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                r.setCharacterEncoding("UTF-8");
+                r.setContentType("application/json;charset=UTF-8");
+                String json = "{\"status\":401,\"code\":\"" + code + "\",\"message\":\"" + message + "\"}";
+                r.getWriter().write(json);
+            } else {
+                response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            }
+        } catch (IOException ignore) { }
     }
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/SecurityConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 import edu.kangwon.university.taxicarpool.auth.JwtAuthenticationFilter;
 import edu.kangwon.university.taxicarpool.auth.JwtUtil;
+import edu.kangwon.university.taxicarpool.member.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -23,9 +24,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
 
-    public SecurityConfig(JwtUtil jwtUtil) {
+    public SecurityConfig(JwtUtil jwtUtil, MemberRepository memberRepository) { // ★ 변경
         this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
     }
 
     @Bean
@@ -39,7 +42,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         // 커스텀 JWT 필터 생성
-        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtUtil);
+        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtUtil, memberRepository);
 
         http
             .cors(withDefaults())

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberEntity.java
@@ -56,6 +56,9 @@ public class MemberEntity {
     @Column(name = "total_saved_amount", nullable = false)
     private long totalSavedAmount = 0L;
 
+    @Column(nullable = false)
+    private int tokenVersion = 0;
+
     public Long getId() {
         return id;
     }
@@ -114,6 +117,14 @@ public class MemberEntity {
 
     public void setTotalSavedAmount(long totalSavedAmount) {
         this.totalSavedAmount = totalSavedAmount;
+    }
+
+    public int getTokenVersion() {
+        return tokenVersion;
+    }
+
+    public void setTokenVersion(int tokenVersion) {
+        this.tokenVersion = tokenVersion;
     }
 
     /** 절감 금액을 누적하는 편의 메서드 */

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/member/MemberRepository.java
@@ -2,6 +2,8 @@ package edu.kangwon.university.taxicarpool.member;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +17,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     // 회원가입, 회원정보 수정 시 닉네임 중복 검증에 사용
     boolean existsByNickname(String nickname);
+
+    @Query("select m.tokenVersion from MemberEntity m where m.id = :id")
+    int findTokenVersionById(@Param("id") Long id);
 }


### PR DESCRIPTION
- 현재 카풀 앱의 인증/인가 로직은 표준적인 JWT 로직으로 구현 되어있다.
    - 엑세스/리프레쉬 토큰을 사용한다.
    - 엑세스 토큰의 기한이 만료되면 사용자는 재로그인 화면을 보지않고, 클라이언트 쪽에서 구현해놓은 리프레쉬 토큰으로 엑세스 토큰 갱신 요청을 자동으로 보내게 된다.
    - 엑세스/리프레쉬 토큰을 적절히 섞어 사용함으로써 보안/UX측면의 중간 지점을 찾을 수 있다.
- 그러나 표준적인 JWT 로직에는 다음과 같은 허점이 있다.
    - 예를들어 엑세스 토큰 유효기간이 2시간이고, 리프레쉬 토큰 유효기간이 2주라고 가정하자.
    - 사용자가 A기기에서 카풀앱을 로그인 해놓은 상태로 1시간이 지났다. 여기서 사용자는 B기기에서 카풀앱 로그인을 한다.
    - 지금 구현해놓은 인증/인가 로직대로라면 다음과 같은 일이 벌어진다. B기기에서 정상적인 로그인이 진행된다. 즉, 새로운 엑세스 토큰을 응답받게 되고 기존 DB의 리프레쉬 토큰 테이블에 새롭게 받은 리프레쉬 토큰이 덮어서 저장하게 된다(리프레쉬 토큰 테이블과 멤버 테이블이 OneToOne이기 때문) 말이 복잡하지만, 결국 기존의 리프레쉬 토큰을 무효화 되고, 새롭게 받은 리프레쉬 토큰만 유효하게 된다.
    - 그래서 B기기에서는 정상적으로 앞으로 2주간(리프레쉬 토큰 유효기간)사용할 수 있다. 그러나 A기기는 엑세스 토큰의 기한이 1시간 남아있다. A기기에서 이 1시간 동안은 문제없이 카풀앱을 사용할 수 있다.
- 다른 기기에서 새롭게 로그인 했을 때 여러 가지 방안이 있을 것이다.
    - 여러 기기 모두에서 로그인이 가능하게 하려면, 멤버 테이블과 리프레쉬 토큰 테이블을 일대다로 매핑할 수 있을 것이다. 또는 기기(device)테이블을 만들어서 리프레쉬 토큰과 다대일로 연결해도 된다. 그러나 우선은 출시 전이고 하나의 기기에서만 허용하도록 구현하는 것이 보안 상 안전하다고 판단된다. 그래서 하나의 기기에서만 허용하도록 구현하자.
- 하나의 기기에서만 로그인 상태를 허용하도록 하기 위해서 이전 예시 상황을 다시 생각해보자. B기기에서 로그인한다면 A기기의 즉각 로그아웃 상태를 만들어야한다.
    - 이전 기기에서 발급받은 엑세스 토큰이라는 것을 식별하기 위해, 다시 말해 유효기간이 남아있더라도 가장 최근에 발급한 엑세스 토큰이 아니라는 것을 식별해야만 엑세스 토큰의 승인을 거부할 수 있게된다.
    - JWT 인증/인가는 stateless라는 특성이 있기 때문에 기본적으로는  서버에 무엇인가를 저장하지 않는 것이 원칙이다.
    - 하지만 가장 최근에 발급 받은 엑세스 토큰인지를 식별하기 위해 엑세스 토큰의 버전을 의미하는 값을 DB에 저장할 것이다.
    - 로그인 요청으로 매번 엑세스 토큰을 발급해줄 때, 기본적인 JWT토큰에 버전을 의미하는 값을 생성하여 DB에 넣고 클레임으로 JWT에 넣고 함께 암호화하여 발급해주면 된다.
    - 그리고 지금 엑세스 토큰을 검증하는 필터(웹소켓 필터에도)에 다음의 기능을 추가하면 된다. 기본적인 JWT 검증을 실시하고(시그니처, 유효기간 등) 버전을 의미하는 클레임을 꺼내서 DB에 존재하는 JWT토큰의 버전값을 비교한다.
    - 버전값이 다르다면 재로그인 요청하라는 예외 처리 메시지와 함께 응답해준다.
    - 여기서 주의할 점은 프론트엔드 단에서는 해당 예외 처리가 나온다면, 로그아웃 요청을 보내면 안 된다. 로그아웃 로직에는 리프레쉬 토큰 무효화 로직이 있어서 새롭게 로그인한 기기도 로그아웃 된다. 그냥 해당 기기에서 로컬에 저장된 액세스/리프레시 토큰 등을 지우고 로그아웃 상태(로그인 전 UI)로 돌려놓으면 된다.