### PR TITLE
feat: fcm 구현

### DIFF
--- a/taxi-carpool/build.gradle
+++ b/taxi-carpool/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/FirebaseConfig.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/config/FirebaseConfig.java
@@ -1,0 +1,39 @@
+package edu.kangwon.university.taxicarpool.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    private static final String FIREBASE_CONFIG_PATH = "knu-carpool-firebase-adminsdk-fbsvc-6dfb3c3cdb.json";
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        // Firebase 서비스 계정 키 파일 로드
+        GoogleCredentials googleCredentials = GoogleCredentials
+            .fromStream(new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream());
+
+        // Firebase 옵션 설정
+        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+            .setCredentials(googleCredentials)
+            .build();
+
+        // Firebase 앱 초기화 (이미 초기화된 경우 기존 앱 사용)
+        FirebaseApp firebaseApp;
+        if (FirebaseApp.getApps().isEmpty()) {
+            firebaseApp = FirebaseApp.initializeApp(firebaseOptions);
+        } else {
+            firebaseApp = FirebaseApp.getInstance();
+        }
+
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmPushService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmPushService.java
@@ -1,0 +1,82 @@
+package edu.kangwon.university.taxicarpool.fcm;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import edu.kangwon.university.taxicarpool.fcm.dto.PushMessageDTO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmPushService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenService fcmTokenService;
+    private final FirebaseMessaging firebaseMessaging;
+
+    /**
+     * 특정 사용자에게 푸시 발송
+     */
+    public void sendPushToUser(Long userId, PushMessageDTO message) {
+        List<FcmTokenEntity> tokens = fcmTokenRepository.findActiveTokensByUserId(userId);
+
+        for (FcmTokenEntity token : tokens) {
+            try {
+                Message fcmMessage = buildFcmMessage(token, message);
+                firebaseMessaging.send(fcmMessage);
+            } catch (FirebaseMessagingException e) {
+                fcmTokenService.handleFcmError(token.getFcmToken(), e.getErrorCode());
+            }
+        }
+    }
+
+    /**
+     * 여러 사용자에게 푸시 발송
+     */
+    public void sendPushToUsers(List<Long> userIds, PushMessageDTO message) {
+        for (Long userId : userIds) {
+            sendPushToUser(userId, message);
+        }
+    }
+
+    /**
+     * 플랫폼별 FCM 메시지 빌드
+     */
+    private Message buildFcmMessage(FcmTokenEntity token, PushMessageDTO message) {
+        Message.Builder messageBuilder = Message.builder()
+            .setToken(token.getFcmToken())
+            .setNotification(Notification.builder()
+                .setTitle(message.getTitle())
+                .setBody(message.getBody())
+                .build())
+            .putAllData(message.getData());
+
+        // iOS/Android별 다른 설정
+        if (token.getPlatform() == Platform.IOS) {
+            messageBuilder.setApnsConfig(ApnsConfig.builder()
+                .setAps(Aps.builder()
+                    .setSound("default")
+                    .setBadge(1)
+                    .build())
+                .build());
+        } else {
+            messageBuilder.setAndroidConfig(AndroidConfig.builder()
+                .setNotification(AndroidNotification.builder()
+                    .setChannelId("taxi_carpool_notifications")
+                    .setDefaultSound(true)
+                    .setPriority(AndroidNotification.Priority.HIGH)
+                    .build())
+                .build());
+        }
+
+        return messageBuilder.build();
+    }
+
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenController.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenController.java
@@ -1,0 +1,45 @@
+package edu.kangwon.university.taxicarpool.fcm;
+
+import edu.kangwon.university.taxicarpool.fcm.dto.FcmTokenUpsertRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "FCM Token", description = "FCM 토큰 관리 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+public class FcmTokenController {
+
+    private final FcmTokenService fcmTokenService;
+
+    /**
+     * FCM 토큰 등록/갱신 (업서트)
+     */
+    @Operation(
+        summary = "FCM 토큰 등록/갱신",
+        description = "클라이언트의 FCM 토큰을 등록하거나 갱신합니다. 동일한 플랫폼의 기존 토큰이 있으면 갱신하고, 없으면 새로 등록합니다."
+    )
+    @PostMapping("/token")
+    public ResponseEntity<Void> upsertFcmToken(
+        @Valid @RequestBody FcmTokenUpsertRequestDTO requestDTO
+    ) {
+        Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication()
+            .getPrincipal();
+
+        fcmTokenService.upsertFcmToken(memberId, requestDTO);
+
+        return ResponseEntity.ok().build();
+    }
+    
+
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenEntity.java
@@ -1,0 +1,93 @@
+package edu.kangwon.university.taxicarpool.fcm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity(name = "fcm_token")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "fcm_token_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "fcm_token", nullable = false, length = 500)
+    private String fcmToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", nullable = false)
+    private Platform platform;
+
+    @Column(name = "device_id")
+    private String deviceId;
+
+    @Column(name = "app_version")
+    private String appVersion;
+
+    @Column(name = "bundle_or_package")
+    private String bundleOrPackage;
+
+    @Column(name = "revoked", nullable = false)
+    private boolean revoked = false;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public FcmTokenEntity(
+        Long userId,
+        String fcmToken,
+        Platform platform,
+        String deviceId,
+        String appVersion,
+        String bundleOrPackage
+    ) {
+        this.userId = userId;
+        this.fcmToken = fcmToken;
+        this.platform = platform;
+        this.deviceId = deviceId;
+        this.appVersion = appVersion;
+        this.bundleOrPackage = bundleOrPackage;
+        this.revoked = false;
+    }
+
+    public void updateToken(
+        String fcmToken,
+        String deviceId,
+        String appVersion,
+        String bundleOrPackage
+    ) {
+        this.fcmToken = fcmToken;
+        this.deviceId = deviceId;
+        this.appVersion = appVersion;
+        this.bundleOrPackage = bundleOrPackage;
+        this.revoked = false;
+    }
+
+    public void revoke() {
+        this.revoked = true;
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenRepository.java
@@ -1,0 +1,42 @@
+package edu.kangwon.university.taxicarpool.fcm;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmTokenEntity, Long> {
+
+    /**
+     * 사용자 ID로 활성 FCM 토큰 목록 조회
+     */
+    @Query("SELECT f FROM fcm_token f WHERE f.userId = :userId AND f.revoked = false")
+    List<FcmTokenEntity> findActiveTokensByUserId(@Param("userId") Long userId);
+
+    /**
+     * 사용자 ID와 플랫폼으로 활성 FCM 토큰 조회
+     */
+    @Query("SELECT f FROM fcm_token f WHERE f.userId = :userId AND f.platform = :platform AND f.revoked = false")
+    Optional<FcmTokenEntity> findActiveTokenByUserIdAndPlatform(
+        @Param("userId") Long userId,
+        @Param("platform") Platform platform
+    );
+
+    /**
+     * 사용자의 모든 토큰을 폐기 상태로 변경 (회원 탈퇴 시 사용)
+     */
+    @Modifying
+    @Query("UPDATE fcm_token f SET f.revoked = true WHERE f.userId = :userId")
+    void revokeAllTokensByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 FCM 토큰을 폐기 상태로 변경
+     */
+    @Modifying
+    @Query("UPDATE fcm_token f SET f.revoked = true WHERE f.fcmToken = :fcmToken")
+    void revokeTokenByFcmToken(@Param("fcmToken") String fcmToken);
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenService.java
@@ -1,0 +1,78 @@
+package edu.kangwon.university.taxicarpool.fcm;
+
+import com.google.firebase.ErrorCode;
+import edu.kangwon.university.taxicarpool.fcm.dto.FcmTokenUpsertRequestDTO;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    /**
+     * FCM 토큰 등록/갱신 (업서트) 동일한 사용자의 동일한 플랫폼 토큰이 있으면 갱신, 없으면 새로 생성
+     */
+    @Transactional
+    public void upsertFcmToken(Long userId, FcmTokenUpsertRequestDTO requestDTO) {
+        Optional<FcmTokenEntity> existingToken = fcmTokenRepository
+            .findActiveTokenByUserIdAndPlatform(userId, requestDTO.getPlatform());
+
+        if (existingToken.isPresent()) {
+            // 기존 토큰이 있으면 업데이트
+            FcmTokenEntity token = existingToken.get();
+            if (!token.getFcmToken().equals(requestDTO.getFcmToken())) {
+                // 토큰이 변경된 경우에만 업데이트
+                token.updateToken(
+                    requestDTO.getFcmToken(),
+                    requestDTO.getDeviceId(),
+                    requestDTO.getAppVersion(),
+                    requestDTO.getBundleOrPackage()
+                );
+            }
+        } else {
+            // 새 토큰 생성
+            FcmTokenEntity newToken = new FcmTokenEntity(
+                userId,
+                requestDTO.getFcmToken(),
+                requestDTO.getPlatform(),
+                requestDTO.getDeviceId(),
+                requestDTO.getAppVersion(),
+                requestDTO.getBundleOrPackage()
+            );
+            fcmTokenRepository.save(newToken);
+        }
+    }
+
+    /**
+     * 특정 FCM 토큰 폐기
+     */
+    @Transactional
+    public void revokeTokenByFcmToken(String fcmToken) {
+        fcmTokenRepository.revokeTokenByFcmToken(fcmToken);
+    }
+
+    /**
+     * FCM 응답 오류에 따른 토큰 폐기 처리
+     */
+    @Transactional
+    public void handleFcmError(String fcmToken, ErrorCode errorCode) {
+        // UNREGISTERED, INVALID_REGISTRATION_TOKEN 등의 오류 시 토큰 폐기
+        if (shouldRevokeToken(errorCode)) {
+            revokeTokenByFcmToken(fcmToken);
+        }
+    }
+
+    /**
+     * FCM 오류 코드에 따라 토큰 폐기 여부 결정
+     */
+    private boolean shouldRevokeToken(ErrorCode errorCode) {
+        String errorCodeStr = errorCode.name();
+        return "UNREGISTERED".equals(errorCodeStr) ||
+            "INVALID_REGISTRATION_TOKEN".equals(errorCodeStr) ||
+            "NOT_FOUND".equals(errorCodeStr);
+    }
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/Platform.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/Platform.java
@@ -1,0 +1,9 @@
+package edu.kangwon.university.taxicarpool.fcm;
+
+/**
+ * FCM 토큰이 등록된 플랫폼을 나타내는 열거형
+ */
+public enum Platform {
+    IOS,
+    ANDROID
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/dto/FcmTokenUpsertRequestDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/dto/FcmTokenUpsertRequestDTO.java
@@ -1,0 +1,24 @@
+package edu.kangwon.university.taxicarpool.fcm.dto;
+
+import edu.kangwon.university.taxicarpool.fcm.Platform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmTokenUpsertRequestDTO {
+
+    @NotBlank(message = "FCM 토큰은 필수입니다.")
+    private String fcmToken;
+
+    @NotNull(message = "플랫폼은 필수입니다.")
+    private Platform platform;
+
+    private String deviceId;
+
+    private String appVersion;
+
+    private String bundleOrPackage;
+}

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/dto/PushMessageDTO.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/dto/PushMessageDTO.java
@@ -1,0 +1,20 @@
+package edu.kangwon.university.taxicarpool.fcm.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PushMessageDTO {
+
+    private String title;
+
+    private String body;
+
+    @Builder.Default
+    private Map<String, String> data = new HashMap<>();
+
+    private String type; // "CHAT", "PARTY_LEAVE", "DEPARTURE_REMINDER"
+}


### PR DESCRIPTION
## 🏗️ 핵심 구조

### **FCM 토큰 엔티티**
```java
@Entity(name = "fcm_token")
@EntityListeners(AuditingEntityListener.class)
public class FcmTokenEntity {
    @Id @GeneratedValue
    private Long id;
    
    @Column(name = "user_id", nullable = false)
    private Long userId;
    
    @Column(name = "fcm_token", nullable = false, length = 500)
    private String fcmToken; // 필수: FCM 토큰
    
    @Enumerated(EnumType.STRING)
    private Platform platform; // 필수: 플랫폼 (IOS/ANDROID)
    
    private String deviceId; // 선택: 디바이스 ID
    private String appVersion; // 선택: 앱 버전
    private String bundleOrPackage; // 선택: 번들/패키지명
    
    @Column(nullable = false)
    private boolean revoked = false;
    
    @CreatedDate @LastModifiedDate
    private LocalDateTime createdAt, updatedAt;
}
```

### **주요 컴포넌트**

1. **FirebaseConfig**: Firebase Admin SDK 초기화 및 Bean 등록
2. **FcmTokenController**: FCM 토큰 등록/갱신 REST API (`POST /api/fcm/token`)
3. **Platform enum**: iOS/Android 플랫폼 구분
4. **FcmTokenUpsertRequestDTO**: 토큰 등록 요청 데이터 (`fcmToken`, `platform` 필수)
5. **PushMessageDTO**: 푸시 메시지 구조 (`title`, `body`, `data`, `type`)

## 🔐 보안 연동

**로그아웃 시 FCM 토큰 자동 폐기:**
```java
// AuthService.logout()에 추가
Long userId = tokenEntity.getMember().getId();
fcmTokenRepository.revokeAllTokensByUserId(userId);
```

## 📋 주요 기능

- **업서트 방식**: 동일 사용자+플랫폼 조합에서 토큰 갱신
- **플랫폼별 관리**: iOS/Android 각각 독립적 토큰 관리
- **JWT 인증 연동**: SecurityContext에서 사용자 ID 추출
- **토큰 폐기**: 로그아웃/탈퇴 시 모든 FCM 토큰 무효화

## 앞으로 구현해야할 기능
- 푸시 알림을 필요로 하는 도메인의 서비스레이어에서 FcmPushService 호출하는 로직
- 프론트에서 FCM 토큰을 발급받아 이를 백엔드에 전송(업서트)하는 로직
- 프론트에서 서비스워커를 구현하여 알림을 수신하는 로직