### PR TITLE
[#261] fix: fcm 메시지 포맷 변경

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/ChattingService.java
@@ -14,6 +14,7 @@ import edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyE
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import edu.kangwon.university.taxicarpool.profanity.ProfanityService;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
@@ -183,8 +184,14 @@ public class ChattingService {
 
         // 2. 알림 받을 사람이 있으면 푸시 발송
         if (!recipientIds.isEmpty()) {
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH시 mm분");
+            String formattedTime = party.getStartDateTime().format(timeFormatter);
+
+            String destinationName = party.getEndPlace().getName();
+            String title = String.format("%s %s행 카풀방", formattedTime, destinationName);
+
             PushMessageDTO pushMessage = PushMessageDTO.builder()
-                .title(party.getName()) // 파티방 이름을 알림 제목으로
+                .title(title)
                 .body(String.format("%s: %s", sender.getNickname(), masked)) // "닉네임: 메시지 내용"
                 .type("CHAT_MESSAGE") // 클라이언트와 협의된 타입
                 .build();

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartySchedulerService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartySchedulerService.java
@@ -45,10 +45,12 @@ public class PartySchedulerService {
 
             // 3. 푸시 메시지 생성
             String formattedDepartureTime = party.getStartDateTime().format(DateTimeFormatter.ofPattern("HH:mm"));
+            String destinationName = party.getEndPlace().getName();
             PushMessageDTO pushMessage = PushMessageDTO.builder()
                 .title("곧 택시가 출발해요! 🚕")
-                .body(String.format("'%s' 파티가 10분 뒤(%s) 출발합니다. 늦지 않게 준비해주세요!",
-                    party.getName(), formattedDepartureTime))
+                // 본문 내용을 party.getName() 대신 destinationName으로 변경
+                .body(String.format("%s행 카풀이 10분 뒤(%s) 출발합니다. 늦지 않게 준비해주세요!",
+                    destinationName, formattedDepartureTime))
                 .type("DEPARTURE_REMINDER")
                 .build();
             pushMessage.getData().put("partyId", String.valueOf(party.getId()));

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyService.java
@@ -18,6 +18,7 @@ import edu.kangwon.university.taxicarpool.party.partyException.PartyInvalidMaxPa
 import edu.kangwon.university.taxicarpool.party.partyException.PartyNotFoundException;
 import edu.kangwon.university.taxicarpool.party.partyException.UnauthorizedHostAccessException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -252,11 +253,17 @@ public class PartyService {
 
         // FCM 푸시 발송
         if (!targetIds.isEmpty()) {
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH시 mm분");
+            String formattedTime = partyEntity.getStartDateTime().format(timeFormatter);
+            String destinationName = partyEntity.getEndPlace().getName();
+
+            String title = String.format("%s %s행 카풀방", formattedTime, destinationName);
+            String body = "호스트에 의해 파티가 삭제되었습니다.";
+
             PushMessageDTO msg = PushMessageDTO.builder()
-                .title("파티가 삭제되었습니다")
-                .body("호스트가 파티를 삭제했어요.")
+                .title(title)
+                .body(body)
                 .type("PARTY_DELETED")
-                // 메시지 타입이 notification이지만 프론트의 딥링크/라우팅에서 사용하기 유용해서 data도 세팅
                 .data(Map.of("partyId", String.valueOf(partyId)))
                 .build();
             fcmPushService.sendPushToUsers(targetIds, msg);


### PR DESCRIPTION
- 채팅방 메시지: title에 party name필드 대신에 시간/목적지 넣기("17시 15분에 남춘천역가는 카풀방")
- 삭제된 카풀: 마찬가지로 시간/목적지 넣고 어떤 카풀방인지 명시
- 출발 10분전: name필드 삭제하고 목적지 추가