### PR TITLE
[#265] fix: 멤버 탈퇴 시, 로직 추가

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetTokenRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/auth/reset/PasswordResetTokenRepository.java
@@ -1,9 +1,11 @@
 package edu.kangwon.university.taxicarpool.auth.reset;
 
+import edu.kangwon.university.taxicarpool.member.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetTokenEntity, Long> {
     Optional<PasswordResetTokenEntity> findByJti(String jti);
+    void deleteAllByMember(MemberEntity member);
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/MessageRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/chatting/MessageRepository.java
@@ -1,8 +1,10 @@
 package edu.kangwon.university.taxicarpool.chatting;
 
+import edu.kangwon.university.taxicarpool.member.MemberEntity;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,5 +23,9 @@ public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
         "ORDER BY m.id ASC")
     List<MessageEntity> findByPartyIdOrderByIdAsc(@Param("partyId") Long partyId,
         Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE MessageEntity m SET m.sender = null WHERE m.sender = :member")
+    void setSenderToNullByMember(@Param("member") MemberEntity member);
 
 }

--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenRepository.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/fcm/FcmTokenRepository.java
@@ -1,5 +1,6 @@
 package edu.kangwon.university.taxicarpool.fcm;
 
+import edu.kangwon.university.taxicarpool.member.MemberEntity;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -41,9 +42,9 @@ public interface FcmTokenRepository extends JpaRepository<FcmTokenEntity, Long> 
     void revokeTokenByFcmToken(@Param("fcmToken") String fcmToken);
 
     /**
-     * 회원 삭제 전에 FK 충돌을 막기 위해 해당 회원의 모든 FCM 토큰을 물리 삭제
+     * 회원 엔티티로 해당 회원의 모든 FCM 토큰을 물리 삭제 (회원 탈퇴 시 사용)
      */
     @Modifying
-    @Query("DELETE FROM fcm_token f WHERE f.member.id = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    @Query("DELETE FROM fcm_token f WHERE f.member = :member")
+    void deleteAllByMember(@Param("member") MemberEntity member);
 }


### PR DESCRIPTION
- 회원이 참여 중인 모든 PartyEntity 목록을 복사하여 순회 후 탈퇴
- member.getParties().clear()로 Member 엔티티와 Party의 연관 관계 명시적 제거
- messageRepository.setSenderToNullByMember(member)를 호출하여 회원이 작성한 모든 MessageEntity의 sender를 null로 업데이트
- passwordResetTokenRepository.deleteAllByMember(member)를 호출하여 연관된 비밀번호 재설정 토큰 삭제