### PR TITLE
[#360] feat: 사용자 사용 패턴에 따른 효율적인 2가지 락 운영 정책 

### DIFF
--- a/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
+++ b/taxi-carpool/src/main/java/edu/kangwon/university/taxicarpool/party/PartyEntity.java
@@ -38,6 +38,9 @@ public class PartyEntity {
     @Column(name = "name")
     private String name;
 
+    @Version
+    private Long version;
+
     @Column(name = "is_deleted")
     private boolean isDeleted;
 

--- a/taxi-carpool/src/main/resources/application-prod.properties
+++ b/taxi-carpool/src/main/resources/application-prod.properties
@@ -63,3 +63,4 @@ resilience4j.circuitbreaker.instances.redis-circuit.ignore-exceptions[4]=edu.kan
 resilience4j.circuitbreaker.instances.redis-circuit.ignore-exceptions[5]=edu.kangwon.university.taxicarpool.member.exception.MemberNotFoundException
 resilience4j.circuitbreaker.instances.redis-circuit.ignore-exceptions[6]=edu.kangwon.university.taxicarpool.party.partyException.MemberNotInPartyException
 resilience4j.circuitbreaker.instances.redis-circuit.ignore-exceptions[7]=edu.kangwon.university.taxicarpool.chatting.exception.InvalidMessageTypeException
+resilience4j.circuitbreaker.instances.redis-circuit.ignore-exceptions[8]=edu.kangwon.university.taxicarpool.party.partyException.PartyLockInterruptedException


### PR DESCRIPTION
## 사용자 사용 패턴에 따른 효율적인 2가지 락 운영 정책

### 문제 배경

- 사용자 사용 패턴 분석 결과, 사용자는 08~20시 사이에 90% 이상의 카풀을 진행함
- 그런데 카풀 참여 API(joinParty)는 Redis를 이용하여 락을 걸고 있음.
- Redis가 인메모리 기반이라 락을 얻고 해제하는 과정 자체가 빠른 편이지만, 네트워크 RTT가 발생함.
- 그렇기 때문에 사람들이 많이 사용하지 않는 시간대에는 물리적/논리적 lock을 걸지 않는 낙관적 락을 걸어두면, 해당 시간대 사용자들이 파티 참여 API 요청을 보냈을 때 더 빠른 응답을 내려줄 수 있음


### 문제 해결을 위한 행동

- 우선, Facade 계층에 Redis 분산락과 낙관적 락을 적용하는 메서드를 각각 만들어둬야함.
- 그리고 낙관적 락 적용을 위해, entity에 @version 필드 추가
- Facade 계층에 LocalTime.now() 메서드를 이용하여 시간을 측정한 뒤, 피크 시간대와 비피크 시간대에 따라 적합한 락이 적용된 joinParty()를 호출할 수 있도록 설계
- entity에 @version 필드가 추가되어 있기 때문에, 07:59~08:00로 넘어가는 경계값에서도 오차가 없게 유지함
- 또한 낙관적 락은 동시 입장의 경우를 대비한 재시도 로직이 필요하기에 적용하고, 새벽 시간대에 반영되는 로직이기 때문에 적은 횟수인, 최대 3회 재시도로 설정


### 테스트 및 성과

- 새벽 시간대에 사용자가 Redis 분산락보다 낙관적 락을 사용했을 때 더 빠른 응답을 받는 것을 검증해야함 
- 이를위해 각 락기법 메서드를 따로 호출하여 A/B테스트를 진행
- 트래픽이 없는 상황이었기 때문에 30명이 가상 사용자가 초당 1명씩 파티에 참여하는 것으로 테스트 진행
- 그 결과 약 35ms의 더 빠른 응답속도를 제공하는 성과를 얻음

### 주의점

- 서킷 브레이커에 무시 해달라고 추가해야 할 예외를 주의해야함
- 서킷 브레이커도 스프링 스록시 객체로 수행되는 스프링 AOP기반임
- 고로 joinParty()메서드 밖에서 예외를 탐지할 준비를 하고 있음
- 따라서 joinParty()메서드 내부에서 catch()로 잡히는 예외는 그 자리에서 대처하기 때문에 서킷 브레이커까지 가지 않음
- 이에 따라 InterruptedException과 ObjectOptimisticLockingFailureException을 추가할 것이 아니라, throw new를 통해 직접 날린 예외(아래 2가지)를 무시해달라고 추가해야함
- PartyFullException / PartyLockInterruptedException